### PR TITLE
Fork test runs

### DIFF
--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -423,7 +423,7 @@ static void DeepState_RunTest(struct DeepState_TestInfo *test) {
 
 #if defined(__cplusplus) && defined(__cpp_exceptions)
     } catch(...) {
-      exit(1);
+      DeepState_Fail();
     }
 #endif  /* __cplusplus */
 


### PR DESCRIPTION
Towards #5.

Will be followed up by a PR that adds a `DeepState_Crash` hook, which executors will consume to write `.crash` test cases.