### PR TITLE
Take-over API

### DIFF
--- a/bin/deepstate/common.py
+++ b/bin/deepstate/common.py
@@ -122,6 +122,10 @@ class DeepState(object):
         help="Directory where tests will be saved.")
 
     parser.add_argument(
+        "--take_over", action='store_true',
+        help="Explore the program starting at the `TakeOver` hook.")
+
+    parser.add_argument(
         "binary", type=str, help="Path to the test binary to run.")
 
     cls._ARGS = parser.parse_args()

--- a/bin/deepstate/main_manticore.py
+++ b/bin/deepstate/main_manticore.py
@@ -21,7 +21,7 @@ import sys
 try:
   import manticore
 except Exception as e:
-  if "Z3NotFoundError" in repr(type(e)):  
+  if "Z3NotFoundError" in repr(type(e)):
     print "Manticore requires Z3 to be installed."
     sys.exit(255)
   else:
@@ -364,22 +364,7 @@ def run_tests(args, state, apis):
   exit(0)
 
 
-def main():
-  args = DeepManticore.parse_args()
-
-  try:
-    m = manticore.Manticore(args.binary)
-  except Exception as e:
-    L.critical("Cannot create Manticore instance on binary {}: {}".format(
-        args.binary, e))
-    return 1
-
-  m.verbosity(1)
-
-  # Hack to get around current broken _get_symbol_address
-  m._binary_type = 'not elf'
-  m._binary_obj = m._initial_state.platform.elf
-
+def main_unit_test(m, args):
   setup_ea = find_symbol_ea(m, 'DeepState_Setup')
   if not setup_ea:
     L.critical("Cannot find symbol `DeepState_Setup` in binary `{}`".format(
@@ -399,6 +384,25 @@ def main():
   del mc
   m.add_hook(setup_ea, lambda state: run_tests(args, state, apis))
   m.run()
+
+
+def main():
+  args = DeepManticore.parse_args()
+
+  try:
+    m = manticore.Manticore(args.binary)
+  except Exception as e:
+    L.critical("Cannot create Manticore instance on binary {}: {}".format(
+        args.binary, e))
+    return 1
+
+  m.verbosity(1)
+
+  # Hack to get around current broken _get_symbol_address
+  m._binary_type = 'not elf'
+  m._binary_obj = m._initial_state.platform.elf
+
+  return main_unit_test(m, args)
 
 
 if "__main__" == __name__:

--- a/bin/deepstate/main_manticore.py
+++ b/bin/deepstate/main_manticore.py
@@ -338,6 +338,10 @@ def do_run_test(state, apis, test):
   m.add_hook(apis['ClearStream'], hook(hook_ClearStream))
   m.add_hook(apis['LogStream'], hook(hook_LogStream))
 
+  # Here we hook `DeepState_TakeOver()`, even if running unit tests.
+  # In that case, we simply will never hit this hooked function model.
+  m.add_hook(test.ea, hook(hook_TakeOver))
+
   m.subscribe('will_terminate_state', done_test)
   m.run()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,3 +43,6 @@ target_link_libraries(StreamingAndFormatting deepstate)
 add_executable(Squares Squares.c)
 target_link_libraries(Squares deepstate)
 set_target_properties(Squares PROPERTIES COMPILE_DEFINITIONS "DEEPSTATE_TEST")
+
+add_executable(TakeOver TakeOver.cpp)
+target_link_libraries(TakeOver deepstate)

--- a/examples/TakeOver.cpp
+++ b/examples/TakeOver.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <deepstate/DeepState.hpp>
+
+using namespace deepstate;
+
+DEEPSTATE_NOINLINE void func(uint32_t x) {
+  CHECK_LT(x, 0x1234)
+    << "Found x=" << x << " was not greater than 0x1234.";
+
+  if (x < 0x1234) {
+    printf("hi\n");
+  } else {
+    printf("bye\n");
+  }
+}
+
+int main(int argc, char *argv[]) {
+  DeepState_InitOptions(argc, argv);
+
+  uint32_t x = 123;
+  func(x);  // Unexplored
+
+  DeepState_TakeOver();
+
+  Symbolic<uint32_t> y;
+  Symbolic<uint32_t> z;
+  func(y);  // Explored
+  func(z);  // Explored
+}

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -55,6 +55,7 @@ DEEPSTATE_BEGIN_EXTERN_C
 
 DECLARE_string(input_test_dir);
 DECLARE_string(output_test_dir);
+DECLARE_string(take_over);
 
 enum {
   DeepState_InputSize = 8192

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -309,6 +309,8 @@ struct DeepState_TestInfo {
 /* Pointer to the last registered `TestInfo` structure. */
 extern struct DeepState_TestInfo *DeepState_LastTestInfo;
 
+extern int DeepState_TakeOver(void);
+
 /* Defines the entrypoint of a test case. This creates a data structure that
  * contains the information about the test, and then creates an initializer
  * function that runs before `main` that registers the test entrypoint with

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -30,6 +30,7 @@ DEFINE_uint(num_workers, 1,
 
 DEFINE_string(input_test_dir, "", "Directory of saved tests to run.");
 DEFINE_string(output_test_dir, "", "Directory where tests will be saved.");
+DEFINE_string(take_over, "", "Replay test cases in take-over mode.");
 
 /* Pointer to the last registers DeepState_TestInfo data structure */
 struct DeepState_TestInfo *DeepState_LastTestInfo = NULL;

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -65,7 +65,13 @@ void DeepState_Crash(void) {
 DEEPSTATE_NORETURN
 void DeepState_Fail(void) {
   DeepState_TestFailed = 1;
-  longjmp(DeepState_ReturnToRun, 1);
+
+  if (FLAGS_take_over) {
+    // We want to communicate the failure to a parent process, so exit.
+    exit(DeepState_TestRunFail);
+  } else {
+    longjmp(DeepState_ReturnToRun, 1);
+  }
 }
 
 /* Mark this test as passing. */

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -391,6 +391,8 @@ void DeepState_RunSavedTakeOverCases(jmp_buf env,
     if (IsTestCaseFile(dp->d_name)) {
       pid_t case_pid = fork();
       if (!case_pid) {
+        DeepState_Begin(test);
+
         size_t path_len = 2 + sizeof(char) * (strlen(test_case_dir) +
                                               strlen(dp->d_name));
         char *path = (char *) malloc(path_len);
@@ -452,7 +454,7 @@ int DeepState_TakeOver(void) {
     .file_name = "__takeover_file",
     .line_number = 0,
   };
-  // DeepState_Begin(&test);
+
   jmp_buf env;
   if (!setjmp(env)) {
     DeepState_RunSavedTakeOverCases(env, &test);

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -364,6 +364,19 @@ void DrMemFuzzFunc(volatile uint8_t *buff, size_t size) {
   }
 }
 
+int DeepState_TakeOver(void) {
+  struct DeepState_TestInfo test = {
+    .prev = NULL,
+    .test_func = NULL,
+    .test_name = "<__TAKE_OVER_TEST>",
+    .file_name = "<__TAKE_OVER_FILE>",
+    .line_number = 0,
+  };
+  DeepState_Begin(&test);
+
+  return 0;
+}
+
 /* Notify that we're about to begin a test while running under Dr. Fuzz. */
 void DeepState_BeginDrFuzz(struct DeepState_TestInfo *test) {
   DeepState_DrFuzzTest = test;

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -368,8 +368,8 @@ int DeepState_TakeOver(void) {
   struct DeepState_TestInfo test = {
     .prev = NULL,
     .test_func = NULL,
-    .test_name = "<__TAKE_OVER_TEST>",
-    .file_name = "<__TAKE_OVER_FILE>",
+    .test_name = "__takeover_test",
+    .file_name = "__takeover_file",
     .line_number = 0,
   };
   DeepState_Begin(&test);

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -411,13 +411,25 @@ void DeepState_RunSavedTakeOverCases(jmp_buf env,
       if (WIFEXITED(wstatus)) {
         uint8_t status = WEXITSTATUS(wstatus);
 
-        if (status) {
+        switch (status) {
+        case DeepState_TestRunPass:
+          DeepState_LogFormat(DeepState_LogInfo,
+                              "Passed: TakeOver test with data from `%s`",
+                              dp->d_name);
+          break;
+        case DeepState_TestRunFail:
           DeepState_LogFormat(DeepState_LogError,
                               "Failed: TakeOver test with data from `%s`",
                               dp->d_name);
-        } else {
-          DeepState_LogFormat(DeepState_LogInfo,
-                              "Passed: TakeOver test with data from `%s`",
+          break;
+        case DeepState_TestRunAbandon:
+          DeepState_LogFormat(DeepState_LogError,
+                              "Abandoned: TakeOver test with data from `%s`",
+                              dp->d_name);
+          break;
+        default:
+          DeepState_LogFormat(DeepState_LogError,
+                              "Unknown exit code from test with data from `%s`",
                               dp->d_name);
         }
       } else {


### PR DESCRIPTION
Closes #6.

This adds a `--take_over` flag to the executors, which causes them to expect the binary to invoke `DeepState_TakeOver()`. At that point, they will take control of the program and symbolically execute it.

- [x] Native impl of `TakeOver`
- [x] angr impl of `TakeOver`
- [x] Manticore impl of `TakeOver`
- [x] Replay of test cases saved in directory