### PR TITLE
Check malloc() for errors

### DIFF
--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -152,6 +152,9 @@ char *DeepState_CStr(size_t len) {
     DeepState_Abandon("Can't create an SIZE_MAX-length string.");
   }
   char *str = (char *) malloc(sizeof(char) * (len + 1));
+  if (NULL == str) {
+    DeepState_Abandon("Can't allocate memory.");
+  }
   if (len) {
     DeepState_SymbolizeData(str, &(str[len - 1]));
   }


### PR DESCRIPTION
Checking for memory allocation failures from malloc() can be a heated debate... But I saw another place doing it in the same file, so if only for consistency and safety, I think it makes sense here.