### PR TITLE
Fixed missing default value in run_test

### DIFF
--- a/bin/deepstate/main_manticore.py
+++ b/bin/deepstate/main_manticore.py
@@ -344,7 +344,7 @@ def do_run_test(state, apis, test, hook_test=False):
   m.run()
 
 
-def run_test(state, apis, test, hook_test):
+def run_test(state, apis, test, hook_test=False):
   try:
     do_run_test(state, apis, test, hook_test)
   except:


### PR DESCRIPTION
This small fix enables Manticore to work properly as a backend.