### PR TITLE
Fix angr error for file_ea

### DIFF
--- a/bin/deepstate/common.py
+++ b/bin/deepstate/common.py
@@ -438,6 +438,7 @@ class DeepState(object):
         return
 
     expr_ea = self.concretize(expr_ea, constrain=True)
+    file_ea = self.concretize(file_ea, constrain=True)    
     constraint = arg != 0
     if not self.add_constraint(constraint):
       expr, _ = self.read_c_string(expr_ea, concretize=False)


### PR DESCRIPTION
Error is same as for expr_ea, this is the same fix.  Seems to avoid angr producing the error message, though I don't have a completed run with assumes to check for sure (but the error appeared much earlier in runtime before).