### PR TITLE
Add --no-export-dynamic to the static link options, allowing clang compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,9 @@ target_compile_options(${PROJECT_NAME} PUBLIC -mno-avx)
 
 target_compile_options(${PROJECT_NAME}32 PUBLIC -m32 -g3 -mno-avx)
 
-target_link_libraries(${PROJECT_NAME} -static "-Wl,--allow-multiple-definition")
+target_link_libraries(${PROJECT_NAME} -static "-Wl,--allow-multiple-definition,--no-export-dynamic")
+
+target_link_libraries(${PROJECT_NAME}32 -static "-Wl,--allow-multiple-definition,--no-export-dynamic")
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC SYSTEM "${CMAKE_SOURCE_DIR}/src/include"


### PR DESCRIPTION
Also fixes that the static options were missing for 32 bit builds; if we're going to compile static, let's just compile static.