### PR TITLE
Reliable SIGSEGV in clang 6.0

### DIFF
--- a/examples/Crash.cpp
+++ b/examples/Crash.cpp
@@ -22,7 +22,7 @@ using namespace deepstate;
 DEEPSTATE_NOINLINE static unsigned segfault(unsigned x) {
   if (x == 0x1234) {  // Magic number for engine to discover
     unsigned *p = NULL;
-    *p = 0xdeadbeef;  // Trigger segfault here
+    *(p+1) = 0xdeadbeef;  // Trigger segfault here
   }
 
   return x;


### PR DESCRIPTION
This will also fix #95 