### PR TITLE
simple fix for libFuzzer ranges

### DIFF
--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -235,7 +235,8 @@ DEEPSTATE_INLINE static void DeepState_Check(int expr) {
     DEEPSTATE_INLINE static tname DeepState_ ## Tname ## InRange( \
         tname low, tname high) { \
       tname x = DeepState_ ## Tname(); \
-      if (!DeepState_UsingLibFuzzer) \
+      if (!(DeepState_UsingLibFuzzer || HAS_FLAGS_input_test_file \
+	    || HAS_FLAGS_input_test_dir || HAS_FLAGS_input_test_files_dir)) \
         (void) DeepState_Assume(low <= x && x <= high); \
       else \
 	x = low + (x%((high+1)-low)); \

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -236,10 +236,10 @@ DEEPSTATE_INLINE static void DeepState_Check(int expr) {
         tname low, tname high) { \
       tname x = DeepState_ ## Tname(); \
       if (!(DeepState_UsingLibFuzzer || HAS_FLAG_input_test_file \
-	    || HAS_FLAG_input_test_dir || HAS_FLAG_input_test_files_dir)) \
+            || HAS_FLAG_input_test_dir || HAS_FLAG_input_test_files_dir)) \
         (void) DeepState_Assume(low <= x && x <= high); \
       else \
-	x = low + (x%((high+1)-low)); \
+        x = low + (x%((high+1)-low)); \
       return x; \
     }
 

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -235,8 +235,8 @@ DEEPSTATE_INLINE static void DeepState_Check(int expr) {
     DEEPSTATE_INLINE static tname DeepState_ ## Tname ## InRange( \
         tname low, tname high) { \
       tname x = DeepState_ ## Tname(); \
-      if (!(DeepState_UsingLibFuzzer || HAS_FLAGS_input_test_file \
-	    || HAS_FLAGS_input_test_dir || HAS_FLAGS_input_test_files_dir)) \
+      if (!(DeepState_UsingLibFuzzer || HAS_FLAG_input_test_file \
+	    || HAS_FLAG_input_test_dir || HAS_FLAG_input_test_files_dir)) \
         (void) DeepState_Assume(low <= x && x <= high); \
       else \
 	x = low + (x%((high+1)-low)); \

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -235,14 +235,11 @@ DEEPSTATE_INLINE static void DeepState_Check(int expr) {
     DEEPSTATE_INLINE static tname DeepState_ ## Tname ## InRange( \
         tname low, tname high) { \
       tname x = DeepState_ ## Tname(); \
-      DeepState_LogFormat(DeepState_LogInfo, "Computing a range"); \
       if (!(DeepState_UsingLibFuzzer || HAS_FLAG_input_test_file \
 	    || HAS_FLAG_input_test_dir || HAS_FLAG_input_test_files_dir)) \
         (void) DeepState_Assume(low <= x && x <= high); \
-      else { \
-        DeepState_LogFormat(DeepState_LogInfo, "Fixing value"); \
+      else \
 	x = low + (x%((high+1)-low)); \
-      } \
       return x; \
     }
 

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -235,14 +235,14 @@ DEEPSTATE_INLINE static void DeepState_Check(int expr) {
     DEEPSTATE_INLINE static tname DeepState_ ## Tname ## InRange( \
         tname low, tname high) { \
       tname x = DeepState_ ## Tname(); \
+      DeepState_LogFormat(DeepState_LogInfo, "Computing a range"); \      
       if (!(DeepState_UsingLibFuzzer || HAS_FLAG_input_test_file \
 	    || HAS_FLAG_input_test_dir || HAS_FLAG_input_test_files_dir)) \
         (void) DeepState_Assume(low <= x && x <= high); \
-      else {						\
-        DeepState_LogFormat(DeepState_LogInfo, \
-			    "Fixing value\n"); \
+      else {
+        DeepState_LogFormat(DeepState_LogInfo, "Fixing value"); \
 	x = low + (x%((high+1)-low)); \
-	\}
+     \}
       return x; \
     }
 

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -235,14 +235,14 @@ DEEPSTATE_INLINE static void DeepState_Check(int expr) {
     DEEPSTATE_INLINE static tname DeepState_ ## Tname ## InRange( \
         tname low, tname high) { \
       tname x = DeepState_ ## Tname(); \
-      DeepState_LogFormat(DeepState_LogInfo, "Computing a range"); \      
+      DeepState_LogFormat(DeepState_LogInfo, "Computing a range"); \
       if (!(DeepState_UsingLibFuzzer || HAS_FLAG_input_test_file \
 	    || HAS_FLAG_input_test_dir || HAS_FLAG_input_test_files_dir)) \
         (void) DeepState_Assume(low <= x && x <= high); \
-      else {
+      else { \
         DeepState_LogFormat(DeepState_LogInfo, "Fixing value"); \
 	x = low + (x%((high+1)-low)); \
-     \}
+      } \
       return x; \
     }
 

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -235,7 +235,10 @@ DEEPSTATE_INLINE static void DeepState_Check(int expr) {
     DEEPSTATE_INLINE static tname DeepState_ ## Tname ## InRange( \
         tname low, tname high) { \
       tname x = DeepState_ ## Tname(); \
-      (void) DeepState_Assume(low <= x && x <= high); \
+      if (!DeepState_UsingLibFuzzer) \
+        (void) DeepState_Assume(low <= x && x <= high); \
+      else \
+	x = low + (x%((high+1)-low)); \
       return x; \
     }
 

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -238,8 +238,11 @@ DEEPSTATE_INLINE static void DeepState_Check(int expr) {
       if (!(DeepState_UsingLibFuzzer || HAS_FLAG_input_test_file \
 	    || HAS_FLAG_input_test_dir || HAS_FLAG_input_test_files_dir)) \
         (void) DeepState_Assume(low <= x && x <= high); \
-      else \
+      else {						\
+        DeepState_LogFormat(DeepState_LogInfo, \
+			    "Fixing value\n"); \
 	x = low + (x%((high+1)-low)); \
+	\}
       return x; \
     }
 

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -601,6 +601,13 @@ extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
   enum DeepState_TestRunResult result = DeepState_RunTestLLVM(test);
 
+  const char* abort_check = getenv("LIBFUZZER_ABORT_ON_FAIL");
+  if (abort_check != NULL) {
+    if ((result == DeepState_TestRunFail) || (result == DeepState_TestRunCrash)) {
+      abort();
+    }
+  }
+
   DeepState_Teardown();
   DeepState_CurrentTestRun = NULL;
   free(mem);

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -298,6 +298,9 @@ int32_t DeepState_MaxInt(int32_t v) {
 void _DeepState_Assume(int expr, const char *expr_str, const char *file,
                        unsigned line) {
   if (!expr) {
+    DeepState_LogFormat(DeepState_LogError,
+                      "%s(%u): Assumption %s failed",
+                      file, line, expr_str);    
     DeepState_Abandon("Assumption failed");
   }
 }

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -299,8 +299,8 @@ void _DeepState_Assume(int expr, const char *expr_str, const char *file,
                        unsigned line) {
   if (!expr) {
     DeepState_LogFormat(DeepState_LogError,
-                      "%s(%u): Assumption %s failed",
-                      file, line, expr_str);    
+                        "%s(%u): Assumption %s failed",
+                        file, line, expr_str);    
     DeepState_Abandon("Assumption failed");
   }
 }


### PR DESCRIPTION
Avoid violating assumptions on ranges, just translate to a good value.