### PR TITLE
Simple brute-force fuzzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,22 @@ argument to see all DeepState options.
 
 DeepState consists of a static library, used to write test harnesses, and command-line _executors_ written in Python. At this time, the best documentation is in the [examples](/examples) and in our [paper](https://agroce.github.io/bar18.pdf).  A more extensive example, using DeepState and libFuzzer to test a user-mode file system, is available [here](https://github.com/agroce/testfs); in particular the [Tests.cpp](https://github.com/agroce/testfs/blob/master/Tests.cpp) file and CMakeLists.txt show DeepState usage.
 
+## Built-In Fuzzer
+
+Every DeepState executable provides a simple built-in fuzzer that
+generates tests using completely random data.  Using this fuzzer is as
+simple as calling the native executable with the `--fuzz` argument.
+The fuzzer also takes a `seed` and `timeout` (default of two minutes)
+to control the fuzzing.  If you want to actually save the test cases
+generated, you need to add a `--output_test_dir` arument to tell
+DeepState where to put the generated tests.  By default fuzzing saves
+only failing and crashing tests.  One more command line argument that
+is particularly useful for fuzzing is the `--log_level` argument,
+which controls how much output each test produces.  By default, this
+is set to show all the logging from your tests, which slows fuzzing,
+but setting it to 2 or higher will only show messages produced by
+tests failing or crashing.
+
 ## Fuzzing with libFuzzer
 
 If you install clang 6.0 or later, and run `cmake` when you install
@@ -121,7 +137,7 @@ generate tests using LlibFuzzer.  Because both DeepState and libFuzzer
 want to be `main`, this requires building a different executable for
 libFuzzer.  The `examples` directory shows how this can be done.  The
 libFuzzer executable works like any other libFuzzer executable, and
-the tests produced can be run using the normal DeepState executable.
+the tests produced can be replayed using the normal DeepState executable.
 For example, generating some tests of the `OneOf` example (up to 5,000
 runs), then running those tests to examine the results, would look
 like:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The [2018 IEEE Cybersecurity Development Conference](https://secdev.ieee.org/201
 
 ## Supported Platforms
 
-DeepState currently targets Linux, with macOS support in progress.
+DeepState currently targets Linux, with macOS support in progress
+(some fuzzers work fine, but symbolic execution is not supported yet.
 
 ## Dependencies
 
@@ -129,6 +130,10 @@ is set to show all the logging from your tests, which slows fuzzing,
 but setting it to 2 or higher will only show messages produced by
 tests failing or crashing.
 
+Note that while symbolic execution only works on Linux, without a 
+fairly complex cross-compliation process, the brute force fuzzer works 
+on macOS or (as far as we know) any Unix-like system.
+
 ## Fuzzing with libFuzzer
 
 If you install clang 6.0 or later, and run `cmake` when you install
@@ -159,7 +164,10 @@ corpus, but fuzzing will work even without an initial corpus, unlike AFL.
 One hint when using libFuzzer is to avoid dynamically allocating
 memory during a test, if that memory would not be freed on a test
 failure.  This will leak memory and libFuzzer will run out of memory
-very quickly in each fuzzing session.
+very quickly in each fuzzing session.  In theory, libFuzzer will work
+on macOS, but getting everything to build with the right version of
+clang can be difficult, since the Apple-provided LLVM is unlikely to
+support libFuzzer on many versions of the operating system.
 
 ## Test case reduction
 
@@ -211,6 +219,8 @@ WRITING REDUCED TEST WITH 20 BYTES TO minrmdirfail.test
 
 You can use `--which_test <testname>` to specify which test to
 run, as with the `--input_which_test` options to test replay.
+
+Test case reduction should work on any OS.
 
 ## Fuzzing with AFL
 
@@ -264,6 +274,10 @@ deferred instrumentation.  You'll need code like:
 
 just before the call to `DeepState_Run()` (which reads the entire
 input file) in your `main`.
+
+Because AFL and other file-based fuzzers only rely on the DeepState
+native test executable, they should (like DeepState's built-in simple
+fuzzer) work fine on macOS and other Unix-like OSes.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ The [2018 IEEE Cybersecurity Development Conference](https://secdev.ieee.org/201
 ## Supported Platforms
 
 DeepState currently targets Linux, with macOS support in progress
-(some fuzzers work fine, but symbolic execution is not supported yet.
+(some fuzzers work fine, but symbolic execution is not well-supported
+yet, without a painful cross-compilation process).
 
 ## Dependencies
 

--- a/bin/deepstate/reducer.py
+++ b/bin/deepstate/reducer.py
@@ -130,6 +130,8 @@ def main():
       cuts = s[0]
       for c in cuts:
         newTest = currentTest[:c[0]] + currentTest[c[1]+1:]
+        if len(newTest) == len(currentTest):
+          continue # Ignore non-shrinking reductions
         r = writeAndRunCandidate(newTest)
         if checks(r):
           print("ONEOF REMOVAL REDUCED TEST TO", len(newTest), "BYTES")

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -592,7 +592,7 @@ DeepState_ForkAndRunTest(struct DeepState_TestInfo *test) {
 /* Run a test case with input initialized by fuzzing. */
 static enum DeepState_TestRunResult
 DeepState_FuzzOneTestCase(struct DeepState_TestInfo *test) {
-  for (int i = 0; i < sizeof(DeepState_Input); i++) {
+  for (int i = 0; i < DeepState_InputSize; i++) {
     DeepState_Input[i] = (char)rand();
   }
 

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -605,12 +605,6 @@ DeepState_FuzzOneTestCase(struct DeepState_TestInfo *test) {
 
   enum DeepState_TestRunResult result = DeepState_ForkAndRunTest(test);
 
-  if (result == DeepState_TestRunFail) {
-    if (HAS_FLAG_output_test_dir) {
-      DeepState_SaveFailingTest();
-    }
-  }
-    
   if (result == DeepState_TestRunCrash) {
     DeepState_LogFormat(DeepState_LogError, "Crashed: %s", test->test_name);
     

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -606,8 +606,6 @@ DeepState_FuzzOneTestCase(struct DeepState_TestInfo *test) {
   enum DeepState_TestRunResult result = DeepState_ForkAndRunTest(test);
 
   if (result == DeepState_TestRunFail) {
-    DeepState_LogFormat(DeepState_LogError, "Failed: %s", test->test_name);
-
     if (HAS_FLAG_output_test_dir) {
       DeepState_SaveFailingTest();
     }
@@ -615,7 +613,7 @@ DeepState_FuzzOneTestCase(struct DeepState_TestInfo *test) {
     
   if (result == DeepState_TestRunCrash) {
     DeepState_LogFormat(DeepState_LogError, "Crashed: %s", test->test_name);
-
+    
     if (HAS_FLAG_output_test_dir) {
       DeepState_SaveCrashingTest();
     }

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -20,7 +20,6 @@
 #include <assert.h>
 #include <dirent.h>
 #include <libgen.h>
-#include <random.h>
 #include <setjmp.h>
 #include <signal.h>
 #include <stdbool.h>

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -725,6 +725,8 @@ static int DeepState_Fuzz(void) {
   long current = (long)time(NULL);
   long diff = 0;
   unsigned i = 0;
+
+  int num_failed_tests = 0;
   while (diff < FLAGS_timeout) {
     i++;
 
@@ -733,7 +735,8 @@ static int DeepState_Fuzz(void) {
     current = (long)time(NULL);
     diff = current-start;
   }
-  LOG(INFO) << "Ran " << i << " tests in " << diff << " seconds.";
+  DeepState_LogFormat(DeepState_LogInfo, "Ran %u tests.  %d failed tests.",
+		      i, num_failed_tests);
 }
 
 /* Run tests from `FLAGS_input_test_files_dir`, under `FLAGS_input_which_test`

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -796,14 +796,16 @@ static int DeepState_Fuzz(void) {
   
   while (diff < FLAGS_timeout) {
     i++;
-
     num_failed_tests += DeepState_FuzzOneTestCase(test);    
     
     current = (long)time(NULL);
     diff = current-start;
   }
+
   DeepState_LogFormat(DeepState_LogInfo, "Ran %u tests.  %d failed tests.",
 		      i, num_failed_tests);
+
+  return num_failed_tests;
 }
 
 /* Run tests from `FLAGS_input_test_files_dir`, under `FLAGS_input_which_test`

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -592,6 +592,8 @@ DeepState_ForkAndRunTest(struct DeepState_TestInfo *test) {
 /* Run a test case with input initialized by fuzzing. */
 static enum DeepState_TestRunResult
 DeepState_FuzzOneTestCase(struct DeepState_TestInfo *test) {
+  DeepState_InputIndex = 0;
+  
   for (int i = 0; i < DeepState_InputSize; i++) {
     DeepState_Input[i] = (char)rand();
   }

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -618,6 +618,11 @@ DeepState_FuzzOneTestCase(struct DeepState_TestInfo *test) {
     DeepState_Crash();
   }
 
+  if (FLAGS_abort_on_fail && ((result == DeepState_TestRunCrash) ||
+			      (result == DeepState_TestRunFail))) {
+      abort();
+  }  
+
   return result;
 }
 
@@ -746,6 +751,8 @@ static int DeepState_RunSingleSavedTestCase(void) {
 
 /* Fuzz test `FLAGS_input_which_test` or first test, if not defined. */
 static int DeepState_Fuzz(void) {
+  DeepState_LogFormat(DeepState_LogInfo, "Starting fuzzing");
+  
   if (HAS_FLAG_seed) {
     srand(FLAGS_seed);
   } else {
@@ -896,7 +903,7 @@ static int DeepState_Run(void) {
     return DeepState_RunSingleSavedTestDir();
   }
 
-  if (HAS_FLAG_fuzz) {
+  if (FLAGS_fuzz) {
     return DeepState_Fuzz();
   }
 

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -65,6 +65,7 @@ DECLARE_bool(take_over);
 DECLARE_bool(abort_on_fail);
 DECLARE_bool(verbose_reads);
 DECLARE_bool(fuzz);
+DECLARE_bool(fuzz_save_passing);
 
 DECLARE_int(log_level);
 DECLARE_int(seed);
@@ -523,7 +524,9 @@ static void DeepState_RunTest(struct DeepState_TestInfo *test) {
   } else {
     DeepState_LogFormat(DeepState_LogInfo, "Passed: %s", test->test_name);
     if (HAS_FLAG_output_test_dir) {
-      DeepState_SavePassingTest();
+      if (!FLAGS_fuzz || FLAGS_fuzz_save_passing) {
+	DeepState_SavePassingTest();
+      }
     }
     exit(DeepState_TestRunPass);
   }

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -41,7 +41,7 @@ DEFINE_bool(fuzz, false, "Perform brute force unguided fuzzing.");
 
 DEFINE_int(log_level, 0, "Minimum level of logging to output.");
 DEFINE_int(seed, 0, "Seed for brute force fuzzing (uses time if not set).");
-DEFINE_int(timeout, 120, "Timeout for brute force fuzzing.")
+DEFINE_int(timeout, 120, "Timeout for brute force fuzzing.");
 
 /* Set to 1 by Manticore/Angr/etc. when we're running symbolically. */
 int DeepState_UsingSymExec = 0;

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -558,14 +558,54 @@ void DeepState_BeginDrFuzz(struct DeepState_TestInfo *test) {
   DrMemFuzzFunc(DeepState_Input, DeepState_InputSize);
 }
 
+void makeFilename(char *name, size_t size) {
+  const char *entities = "0123456789abcdef";
+  for (int i = 0; i < size; i++) {
+    name[i] = entities(rand() % 16);
+  }
+}
+
+void writeInputData(char* path) {
+  size_t path_len = 2 + sizeof(char) * (strlen(FLAGS_output_test_dir) + strlen(name));
+  char *path = (char *) malloc(path_len);
+  snprintf(path, path_len, "%s/%s", FLAGS_output_test_dir, name);
+  FILE *fp = fopen(path, "wb");
+  if (fp == NULL) {
+    DeepState_LogFormat(DeepState_LogError, "Failed to write to file `%s`", path);
+    free(path);
+    return;
+  }
+  free(path);
+  fwrite(DeepState_Input, 1, DeepState_InputSize, fp);
+  fclose(fp);  
+}
+
 /* Save a passing test to the output test directory. */
-void DeepState_SavePassingTest(void) {}
+void DeepState_SavePassingTest(void) {
+  char name[48];
+  makeFilename(name, 40);
+  name[40] = NULL;
+  strncat(name, ".pass", 48);
+  writeInputData(name);
+}
 
 /* Save a failing test to the output test directory. */
-void DeepState_SaveFailingTest(void) {}
+void DeepState_SaveFailingTest(void) {
+  char name[48];
+  makeFilename(name, 40);
+  name[40] = NULL;
+  strncat(name, ".fail", 48);
+  writeInputData(name);
+}
 
 /* Save a crashing test to the output test directory. */
-void DeepState_SaveCrashingTest(void) {}
+void DeepState_SaveCrashingTest(void) {
+  char name[48];
+  makeFilename(name, 40);
+  name[40] = NULL;
+  strncat(name, ".crash", 48);
+  writeInputData(name);
+}
 
 /* Return the first test case to run. */
 struct DeepState_TestInfo *DeepState_FirstTest(void) {

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -561,11 +561,11 @@ void DeepState_BeginDrFuzz(struct DeepState_TestInfo *test) {
 void makeFilename(char *name, size_t size) {
   const char *entities = "0123456789abcdef";
   for (int i = 0; i < size; i++) {
-    name[i] = entities(rand() % 16);
+    name[i] = entities[rand()%16];
   }
 }
 
-void writeInputData(char* path) {
+void writeInputData(char* name) {
   size_t path_len = 2 + sizeof(char) * (strlen(FLAGS_output_test_dir) + strlen(name));
   char *path = (char *) malloc(path_len);
   snprintf(path, path_len, "%s/%s", FLAGS_output_test_dir, name);
@@ -576,7 +576,8 @@ void writeInputData(char* path) {
     return;
   }
   free(path);
-  fwrite(DeepState_Input, 1, DeepState_InputSize, fp);
+  fwrite((void *)DeepState_Input, 1, DeepState_InputSize, fp);
+  DeepState_LogFormat(DeepState_LogInfo, "Saved test case to file `%s`", path);
   fclose(fp);  
 }
 
@@ -584,7 +585,7 @@ void writeInputData(char* path) {
 void DeepState_SavePassingTest(void) {
   char name[48];
   makeFilename(name, 40);
-  name[40] = NULL;
+  name[40] = 0;
   strncat(name, ".pass", 48);
   writeInputData(name);
 }
@@ -593,7 +594,7 @@ void DeepState_SavePassingTest(void) {
 void DeepState_SaveFailingTest(void) {
   char name[48];
   makeFilename(name, 40);
-  name[40] = NULL;
+  name[40] = 0;
   strncat(name, ".fail", 48);
   writeInputData(name);
 }
@@ -602,7 +603,7 @@ void DeepState_SaveFailingTest(void) {
 void DeepState_SaveCrashingTest(void) {
   char name[48];
   makeFilename(name, 40);
-  name[40] = NULL;
+  name[40] = 0;
   strncat(name, ".crash", 48);
   writeInputData(name);
 }

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -38,6 +38,7 @@ DEFINE_bool(take_over, false, "Replay test cases in take-over mode.");
 DEFINE_bool(abort_on_fail, false, "Abort on file replay failure (useful in file fuzzing).");
 DEFINE_bool(verbose_reads, false, "Report on bytes being read during execution of test.");
 DEFINE_bool(fuzz, false, "Perform brute force unguided fuzzing.");
+DEFINE_bool(fuzz_save_passing, false, "Save passing tests during fuzzing.");
 
 DEFINE_int(log_level, 0, "Minimum level of logging to output.");
 DEFINE_int(seed, 0, "Seed for brute force fuzzing (uses time if not set).");

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -37,8 +37,11 @@ DEFINE_string(output_test_dir, "", "Directory where tests will be saved.");
 DEFINE_bool(take_over, false, "Replay test cases in take-over mode.");
 DEFINE_bool(abort_on_fail, false, "Abort on file replay failure (useful in file fuzzing).");
 DEFINE_bool(verbose_reads, false, "Report on bytes being read during execution of test.");
+DEFINE_bool(fuzz, false, "Perform brute force unguided fuzzing.");
 
 DEFINE_int(log_level, 0, "Minimum level of logging to output.");
+DEFINE_int(seed, 0, "Seed for brute force fuzzing (uses time if not set).");
+DEFINE_int(timeout, 120, "Timeout for brute force fuzzing.")
 
 /* Set to 1 by Manticore/Angr/etc. when we're running symbolically. */
 int DeepState_UsingSymExec = 0;

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -558,6 +558,7 @@ void DeepState_BeginDrFuzz(struct DeepState_TestInfo *test) {
   DrMemFuzzFunc(DeepState_Input, DeepState_InputSize);
 }
 
+/* Right now "fake" a hexdigest by just using random bytes.  Not ideal. */
 void makeFilename(char *name, size_t size) {
   const char *entities = "0123456789abcdef";
   for (int i = 0; i < size; i++) {

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -571,13 +571,17 @@ void writeInputData(char* name) {
   snprintf(path, path_len, "%s/%s", FLAGS_output_test_dir, name);
   FILE *fp = fopen(path, "wb");
   if (fp == NULL) {
-    DeepState_LogFormat(DeepState_LogError, "Failed to write to file `%s`", path);
+    DeepState_LogFormat(DeepState_LogError, "Failed to create file `%s`", path);
     free(path);
     return;
   }
-  free(path);
-  fwrite((void *)DeepState_Input, 1, DeepState_InputSize, fp);
-  DeepState_LogFormat(DeepState_LogInfo, "Saved test case to file `%s`", path);
+  size_t written = fwrite((void *)DeepState_Input, 1, DeepState_InputSize, fp);
+  if (written != DeepState_InputSize) {
+    DeepState_LogFormat(DeepState_LogError, "Failed to write to file `%s`", path);
+  } else {
+    DeepState_LogFormat(DeepState_LogInfo, "Saved test case to file `%s`", path);
+  }
+  free(path);  
   fclose(fp);  
 }
 

--- a/src/lib/Option.c
+++ b/src/lib/Option.c
@@ -125,7 +125,8 @@ static void ProcessOptionString(void) {
         if (' ' == *ch || DeepState_FakeSpace == *ch) {
           *ch = '\0';
           state = kSeenSpace;
-
+	} else if ('-' == *ch) {
+	  state = kSeenDash;
         } else if (IsValidValueChar(*ch)) {  /* E.g. `--tools bbcount`. */
           state = kInValue;
           DeepState_OptionValues[num_options - 1] = ch;


### PR DESCRIPTION
This will just populate the input buffer with random values and let fly.  It will only save failing/crashing tests.  Has options to control seed and timeout (default of two minutes).