### PR TITLE
Fix Eclipser interface

### DIFF
--- a/bin/deepstate/eclipser.py
+++ b/bin/deepstate/eclipser.py
@@ -49,7 +49,7 @@ def main():
 
   parser.add_argument(
     "--verbose", type=int, help="Verbosity level.",
-      default=1)
+      default=None)
 
   parser.add_argument(
     "--exectimeout", type=int, help="Execution timeout (ms) for Eclipser fuzz runs.",
@@ -100,9 +100,11 @@ def main():
     sys.exit(1)
 
   cmd = ["dotnet", eclipser, "fuzz"]
-  cmd += ["-p", deepstate, "-v", str(args.verbose)]
+  cmd += ["-p", deepstate]
+  if args.verbose is not None:
+    cmd += ["-v", str(args.verbose)]
   cmd += ["-t", str(args.timeout), "-o", out + "/eclipser.run", "--src", "file"]
-  deepargs = "--input_test_file eclipser.input --abort_on_fail"
+  deepargs = "--input_test_file eclipser.input --abort_on_fail --no_fork"
   if whichTest is not None:
       deepargs += " --input_which_test " + whichTest
   cmd += ["--initarg", deepargs]

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -247,6 +247,12 @@ DEEPSTATE_INLINE static void DeepState_Assert(int expr) {
   }
 }
 
+/* Used to make DeepState really crash for fuzzers, on any platform. */
+DEEPSTATE_INLINE static void DeepState_HardCrash() {
+  char *p = 0;
+  (*p) = 0;
+}
+
 /* Asserts that `expr` must hold. If it does not, then the test fails, but
  * nonetheless continues on. */
 DEEPSTATE_INLINE static void DeepState_Check(int expr) {
@@ -578,6 +584,9 @@ static int DeepState_RunTestNoFork(struct DeepState_TestInfo *test) {
     if (HAS_FLAG_output_test_dir) {
       DeepState_SaveFailingTest();
     }
+    if (HAS_FLAG_abort_on_fail) {
+      DeepState_HardCrash();
+    }
     return(DeepState_TestRunFail);
 
     /* The test was abandoned. We may have gotten soft failures before
@@ -753,7 +762,7 @@ static int DeepState_RunSingleSavedTestCase(void) {
 
   if ((result == DeepState_TestRunFail) || (result == DeepState_TestRunCrash)) {    
     if (FLAGS_abort_on_fail) {
-      assert(0); // Terminate in a way AFL/etc. can see as a crash
+      DeepState_HardCrash();
     }
     if (FLAGS_exit_on_fail) {
       exit(255); // Terminate the testing
@@ -829,7 +838,7 @@ static int DeepState_RunSingleSavedTestDir(void) {
 
       if ((result == DeepState_TestRunFail) || (result == DeepState_TestRunCrash)) {
 	if (FLAGS_abort_on_fail) {
-	  assert(0); // Terminate in a way AFL/etc. can see as a crash
+	  DeepState_HardCrash();
 	}
 	if (FLAGS_exit_on_fail) {
 	  exit(255); // Terminate the testing

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -920,6 +920,9 @@ void __assert_fail(const char * assertion, const char * file,
   DeepState_LogFormat(DeepState_LogFatal,
                       "%s(%u): Assertion %s failed in function %s",
                       file, line, assertion, function);
+  if (FLAGS_abort_on_fail) {
+    assert(0); // Terminate the testing in a way AFL/etc. can see as a crash
+  }
   __builtin_unreachable();
 }
 

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -833,7 +833,7 @@ enum DeepState_TestRunResult DeepState_FuzzOneTestCase(struct DeepState_TestInfo
 
   if (FLAGS_abort_on_fail && ((result == DeepState_TestRunCrash) ||
 			      (result == DeepState_TestRunFail))) {
-    assert(0); // Terminate the testing in a way AFL/etc. can see as a crash
+    DeepState_HardCrash();
   }
 
   if (FLAGS_exit_on_fail && ((result == DeepState_TestRunCrash) ||
@@ -921,7 +921,7 @@ void __assert_fail(const char * assertion, const char * file,
                       "%s(%u): Assertion %s failed in function %s",
                       file, line, assertion, function);
   if (FLAGS_abort_on_fail) {
-    assert(0); // Terminate the testing in a way AFL/etc. can see as a crash
+    DeepState_HardCrash();
   }
   __builtin_unreachable();
 }


### PR DESCRIPTION
- First, make Eclipser run with `--no_fork` since it doesn't work with forks.  This is done.  Also, made us default to Eclipser's default verbosity, but you can set it.

- Next, need to figure out how to make ``--no_fork` work right with `--abort_on_fail`  -- not essential, but would clean things up some in Eclipser output, by id-ing crashes properly