### PR TITLE
Keep track of where range removal and byte reduction got to, add del4/del8 after reduce

### DIFF
--- a/bin/deepstate/reducer.py
+++ b/bin/deepstate/reducer.py
@@ -213,6 +213,8 @@ def main():
         if checks(r):
           print("ONEOF REMOVAL REDUCED TEST TO", len(newTest), "BYTES")
           changed = True
+          rangeRemovePos = 0
+          byteReducePos = 0
           break
 
       if (not args.fast) and (not changed):
@@ -225,6 +227,7 @@ def main():
             if checks(r):
               print("BYTE RANGE REMOVAL REDUCED TEST TO", len(newTest), "BYTES")
               rangeRemovePos = b
+              byteReducePos = 0
               changed = True
               break
           if changed:
@@ -240,6 +243,7 @@ def main():
             if checks(r):
               print("BYTE RANGE REMOVAL REDUCED TEST TO", len(newTest), "BYTES")
               rangeRemovePos = b
+              byteReducePos = 0
               changed = True
               break
           if changed:
@@ -270,6 +274,7 @@ def main():
                   print("ONEOF SWAP @ BYTE", cuti[0], "[" + " ".join(map(str, bytesi)) + "]", "WITH",
                           cutj[0], "[" + " ".join(map(str, bytesj)) + "]")
                   changed = True
+                  byteReducePos = 0
                   break
           if changed:
             break

--- a/bin/deepstate/reducer.py
+++ b/bin/deepstate/reducer.py
@@ -189,7 +189,7 @@ def main():
   initialSize = float(len(currentTest))
   iteration = 0
   changed = True
-  
+
   rangeRemovePos = 0
   byteReducePos = 0
 
@@ -230,6 +230,23 @@ def main():
           if changed:
             break
 
+      if (not args.fast) and (not changed):
+        for b in range(0, rangeRemovePos):
+          if args.verbose:
+            print("TRYING BYTE RANGE REMOVAL FROM BYTE", str(b) + "...")
+          for v in range(b+1, len(currentTest)):
+            newTest = currentTest[:b] + currentTest[v:]
+            r = writeAndRunCandidate(newTest)
+            if checks(r):
+              print("BYTE RANGE REMOVAL REDUCED TEST TO", len(newTest), "BYTES")
+              rangeRemovePos = b
+              changed = True
+              break
+          if changed:
+            break
+
+      rangeRemovePos = 0
+
       if not changed:
         if args.verbose:
           print("TRYING ONEOF SWAPPING...")
@@ -260,7 +277,7 @@ def main():
       if not changed:
         if args.verbose:
           print("TRYING BYTE REDUCTIONS...")
-        for b in range(0, len(currentTest)):
+        for b in range(byteReducePos, len(currentTest)):
           for v in range(0, currentTest[b]):
             newTest = bytearray(currentTest)
             newTest[b] = v
@@ -268,14 +285,31 @@ def main():
             if checks(r):
               print("BYTE REDUCTION: BYTE", b, "FROM", currentTest[b], "TO", v)
               changed = True
+              byteReducePos = b+1
               break
           if changed:
             break
 
       if not changed:
+        for b in range(0, byteReducePos):
+          for v in range(0, currentTest[b]):
+            newTest = bytearray(currentTest)
+            newTest[b] = v
+            r = writeAndRunCandidate(newTest)
+            if checks(r):
+              print("BYTE REDUCTION: BYTE", b, "FROM", currentTest[b], "TO", v)
+              changed = True
+              byteReducePos = b+1
+              break
+          if changed:
+            break
+
+      byteReducePos = 0
+
+      if not changed:
         if args.verbose:
-          print("TRYING BYTE REDUCE AND DELETES...")
-        for b in range(0, len(currentTest)):
+          print("TRYING BYTE REDUCE AND DELETE...")
+        for b in range(0, len(currentTest)-1):
           if currentTest[b] == 0:
             continue
           newTest = bytearray(currentTest)
@@ -284,6 +318,36 @@ def main():
           r = writeAndRunCandidate(newTest)
           if checks(r):
             print("BYTE REDUCE AND DELETE AT BYTE", b)
+            changed = True
+            break
+
+      if not changed:
+        if args.verbose:
+          print("TRYING BYTE REDUCE AND DELETE 4...")
+        for b in range(0, len(currentTest)-5):
+          if currentTest[b] == 0:
+            continue
+          newTest = bytearray(currentTest)
+          newTest[b] = currentTest[b]-1
+          newTest = newTest[:b+1] + newTest[b+5:]
+          r = writeAndRunCandidate(newTest)
+          if checks(r):
+            print("BYTE REDUCE AND DELETE 4 AT BYTE", b)
+            changed = True
+            break
+
+      if not changed:
+        if args.verbose:
+          print("TRYING BYTE REDUCE AND DELETE 8...")
+        for b in range(0, len(currentTest)-9):
+          if currentTest[b] == 0:
+            continue
+          newTest = bytearray(currentTest)
+          newTest[b] = currentTest[b]-1
+          newTest = newTest[:b+1] + newTest[b+9:]
+          r = writeAndRunCandidate(newTest)
+          if checks(r):
+            print("BYTE REDUCE AND DELETE 8 AT BYTE", b)
             changed = True
             break
 

--- a/bin/deepstate/reducer.py
+++ b/bin/deepstate/reducer.py
@@ -244,8 +244,8 @@ def main():
               break
           if changed:
             break
-
-      rangeRemovePos = 0
+        if not changed:
+          rangeRemovePos = 0
 
       if not changed:
         if args.verbose:
@@ -303,8 +303,8 @@ def main():
               break
           if changed:
             break
-
-      byteReducePos = 0
+        if not changed:
+          byteReducePos = 0
 
       if not changed:
         if args.verbose:

--- a/bin/deepstate/reducer.py
+++ b/bin/deepstate/reducer.py
@@ -189,6 +189,9 @@ def main():
   initialSize = float(len(currentTest))
   iteration = 0
   changed = True
+  
+  rangeRemovePos = 0
+  byteReducePos = 0
 
   try:
     while changed:
@@ -213,7 +216,7 @@ def main():
           break
 
       if (not args.fast) and (not changed):
-        for b in range(0, len(currentTest)):
+        for b in range(rangeRemovePos, len(currentTest)):
           if args.verbose:
             print("TRYING BYTE RANGE REMOVAL FROM BYTE", str(b) + "...")
           for v in range(b+1, len(currentTest)):
@@ -221,6 +224,7 @@ def main():
             r = writeAndRunCandidate(newTest)
             if checks(r):
               print("BYTE RANGE REMOVAL REDUCED TEST TO", len(newTest), "BYTES")
+              rangeRemovePos = b
               changed = True
               break
           if changed:

--- a/bin/deepstate/reducer.py
+++ b/bin/deepstate/reducer.py
@@ -264,7 +264,7 @@ def main():
             cutj = cuts[j]
             if cutj[0] > cuti[1]:
               bytesj = currentTest[cutj[0]:cutj[1] + 1]
-              if bytesi > bytesj:
+              if (len(bytesj) > 0) and (bytesi > bytesj):
                 newTest = currentTest[:cuti[0]] + bytesj + currentTest[cuti[1]+1:cutj[0]]
                 newTest += bytesi
                 newTest += currentTest[cutj[1]+1:]


### PR DESCRIPTION
One is just the greedy with memory from Hypothesis/TSTL, other change matches pattern where byte N is a count, and then ints/longs follow.  Right now we only handle bytes, but often it is multibyte patterns following