### PR TITLE
Refactor for Manticore 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ install:
 - pip3 install pip
 - pip3.6 -V
 - pip3.6 install pyflakes
+- pip3.6 install z3-solver==4.5.1.0.post2
 - pip3.6 install angr
-- pip3.6 install https://github.com/trailofbits/manticore/archive/b590c41339e549689fdb9c5297735c1a0654b7fd.zip
+- pip3.6 install git+git://github.com/trailofbits/manticore.git
 - mkdir build
 - cd build
 - cmake ..

--- a/bin/deepstate/main_manticore.py
+++ b/bin/deepstate/main_manticore.py
@@ -29,8 +29,10 @@ except Exception as e:
 import traceback
 from .common import DeepState, TestInfo
 
+from manticore.utils import config
+from manticore.utils import log
 from manticore.core.state import TerminateState
-
+from manticore.native.manticore import _make_initial_state
 
 L = logging.getLogger("deepstate.mcore")
 L.setLevel(logging.INFO)
@@ -280,7 +282,7 @@ def _is_program_exit(reason):
   return 'Program finished with exit status' in str(reason)
 
 
-def done_test(_, state, state_id, reason):
+def done_test(_, state, reason):
   """Called when a state is terminated."""
   mc = DeepManticore(state)
 
@@ -289,21 +291,21 @@ def done_test(_, state, state_id, reason):
   # DeepState API, so we can just report it as is. Otherwise, we check to see if
   # it was due to behavior that would typically crash the program being analyzed.
   # If so, we save it as a crash. If not, we abandon it.
-  
+
   if str(OUR_TERMINATION_REASON) != str(reason):
     if _is_program_crash(reason):
       L.info("State {} terminated due to crashing program behavior: {}".format(
-        state_id, reason))
+        state._id, reason))
 
       # Don't raise new `TerminateState` exception
       super(DeepManticore, mc).crash_test()
     elif _is_program_exit(reason):
       L.info("State {} terminated due to program exit: {}".format(
-        state_id, reason))
+        state._id, reason))
       super(DeepManticore, mc).pass_test()
-      #super(DeepManticore, mc).abandon_test()      
+      #super(DeepManticore, mc).abandon_test()
     else:
-      L.error("State {} terminated due to internal error: {}".format(state_id,
+      L.error("State {} terminated due to internal error: {}".format(state._id,
                                                                      reason))
 
       # Don't raise new `TerminateState` exception
@@ -328,21 +330,24 @@ def find_symbol_ea(m, name):
   return 0
 
 
-def do_run_test(state, apis, test, hook_test=False):
+def do_run_test(state, apis, test, workspace, hook_test=False):
   """Run an individual test case."""
   state.cpu.PC = test.ea
-  m = manticore.native.Manticore(state, sys.argv[1:])
-  #m = MainThreadWrapper(m, _CONTROLLER)
-  m.verbosity(1)
 
-  state = m.initial_state
   mc = DeepManticore(state)
+  mc.context['apis'] = apis
 
   # Tell the system that we're using symbolic execution.
   mc.write_uint32_t(apis["UsingSymExec"], 8589934591)
 
   mc.begin_test(test)
+
   del mc
+
+  # NOTE(alan): cannot init State with new native.Manticore in 0.3.0 as it
+  # will try to delete the non-existent stored state from new workspace
+  m = manticore.native.Manticore(state, sys.argv[1:], workspace_url=workspace)
+  log.set_verbosity(1)
 
   m.add_hook(apis['IsSymbolicUInt'], hook(hook_IsSymbolicUInt))
   m.add_hook(apis['ConcretizeData'], hook(hook_ConcretizeData))
@@ -366,42 +371,36 @@ def do_run_test(state, apis, test, hook_test=False):
     m.add_hook(test.ea, hook(hook_TakeOver))
 
   m.subscribe('will_terminate_state', done_test)
-  m.run(procs=1)
+  m.run()
 
 
-def run_test(state, apis, test, hook_test=False):
+def run_test(state, apis, test, workspace, hook_test=False):
   try:
-    do_run_test(state, apis, test, hook_test)
+    do_run_test(state, apis, test, workspace, hook_test)
   except:
     L.error("Uncaught exception: {}\n{}".format(
       sys.exc_info()[0], traceback.format_exc()))
 
 
-def run_tests(args, state, apis):
-  """Run all of the test cases."""
-  #pool = multiprocessing.Pool(processes=max(1, args.num_workers))
-  results = []
+def run_tests(args, state, apis, workspace):
   mc = DeepManticore(state)
+  mc.context['apis'] = apis
   tests = mc.find_test_cases()
 
   L.info("Running {} tests across {} workers".format(
     len(tests), args.num_workers))
 
   for test in tests:
-    res = run_test(state, apis, test)
-    results.append(res)
+    run_test(state, apis, test, workspace)
 
-  #pool.close()
-  #pool.join()
-
-  exit(0)
 
 def get_base(m):
-  e_type = m.initial_state.platform.elf['e_type']
+  initial_state = _make_initial_state(m.binary_path)
+  e_type = initial_state.platform.elf['e_type']
   if e_type == 'ET_EXEC':
     return 0x0
   elif e_type == 'ET_DYN':
-    if m.initial_state.cpu.address_bit_size == 32:
+    if initial_state.cpu.address_bit_size == 32:
       return 0x56555000
     else:
       return 0x555555554000
@@ -417,7 +416,7 @@ def main_takeover(m, args, takeover_symbol):
       args.binary))
     return 1
 
-  takeover_state = m._initial_state
+  takeover_state = _make_initial_state(m.binary_path)
 
   mc = DeepManticore(takeover_state)
 
@@ -434,10 +433,10 @@ def main_takeover(m, args, takeover_symbol):
   fake_test = TestInfo(takeover_ea, '_takeover_test', '_takeover_file', 0)
 
   hook_test = not args.klee
-  takeover_hook = lambda state: run_test(state, apis, fake_test, hook_test)
+  takeover_hook = lambda state: run_test(state, apis, fake_test, m._workspace.uri, hook_test)
   m.add_hook(takeover_ea, takeover_hook)
 
-  m.run(procs=1)
+  m.run()
 
 
 def main_unit_test(m, args):
@@ -447,7 +446,7 @@ def main_unit_test(m, args):
       args.binary))
     return 1
 
-  setup_state = m._initial_state
+  setup_state = _make_initial_state(m.binary_path)
 
   mc = DeepManticore(setup_state)
 
@@ -460,12 +459,16 @@ def main_unit_test(m, args):
   apis = mc.read_api_table(ea_of_api_table, base)
   del mc
 
-  m.add_hook(setup_ea, lambda state: run_tests(args, state, apis))
-  m.run(procs=1)
+  m.add_hook(setup_ea, lambda state: run_tests(args, state, apis, m._workspace.uri))
+  m.run()
 
 
 def main():
   args = DeepManticore.parse_args()
+
+  consts = config.get_group("core")
+  consts.procs = args.num_workers
+  consts.mprocessing = consts.mprocessing.threading
 
   try:
     m = manticore.native.Manticore(args.binary)
@@ -474,11 +477,7 @@ def main():
       args.binary, e))
     return 1
 
-  m.verbosity(args.verbosity)
-
-  # Hack to get around current broken _get_symbol_address
-  m._binary_type = 'not elf'
-  m._binary_obj = m._initial_state.platform.elf
+  log.set_verbosity(args.verbosity)
 
   if args.take_over:
     return main_takeover(m, args, 'DeepState_TakeOver')

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,7 +92,7 @@ RUN cd deepstate \
     && CXX=$ANGORA/bin/angora-clang++ CC=$ANGORA/bin/angora-clang cmake ../ \
     && export USE_TRACK=1 && sudo -E bash -c 'make -i install' \
     && cd .. \
-    && sudo pip3 install 'z3-solver==4.5.1.0.post2' angr 'manticore==0.2.5' \
+    && sudo pip3 install 'z3-solver==4.5.1.0.post2' angr git+git://github.com/trailofbits/manticore.git \
     && sudo python3 ./build/setup.py install
 
 ENV CC=clang


### PR DESCRIPTION
A `ManticoreBase` refactor (see https://github.com/trailofbits/manticore/commit/a527e818301e36e7f7005db4d2f5999b38d6453a) breaks the executor as so:

```
$ deepstate-manticore --num_workers 4 --output_test_dir out ./test_trezor

Traceback (most recent call last):
  File "/home/vagrant/deepstate/venv/bin/deepstate-manticore", line 11, in <module>
    load_entry_point('deepstate==0.1', 'console_scripts', 'deepstate-manticore')()
  File "/home/vagrant/deepstate/venv/lib/python3.6/site-packages/deepstate-0.1-py3.6.egg/deepstate/main_manticore.py", line 481, in main
AttributeError: 'Manticore' object has no attribute '_initial_state'
```
Since `self._initial_state` doesn't exist as an attribute in `core.ManticoreBase`, we use the `_make_initial_state` helper (kinda hacky) to generate a `State` object instead.