### PR TITLE
Ensembler Mode

### DIFF
--- a/bin/deepstate/ensembler.py
+++ b/bin/deepstate/ensembler.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3.6
+# Copyright (c) 2019 Trail of Bits, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+logging.basicConfig()
+
+import os
+import sys
+import time
+import importlib
+import argparse
+import multiprocessing
+
+from collections import defaultdict
+from multiprocessing import Process
+
+from .frontend import DeepStateFrontend
+
+
+# dynamically imports any known subclass of DeepStateFrontend
+# TODO(alan): refactor with any safe sanity checks?
+for subclass in DeepStateFrontend.__subclasses__():
+  __import__(subclass.__module__, globals(), locals(), [subclass.__name__])
+  globals().update({subclass.__name__:
+                    getattr(sys.modules[subclass.__module__], subclass.__name__)})
+
+
+L = logging.getLogger("deepstate.ensembler")
+L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
+
+
+class Ensembler:
+
+  def __init__(self, target, seeds, out_dir, out_sync, num_cores, timeout, workspace, \
+               compiler_args=None, ignore_list=None):
+
+    self.seeds = os.path.abspath(seeds)
+    self.out_dir = os.path.abspath(out_dir)
+    self.sync_dir = os.path.abspath(out_sync)
+    self.workspace = os.path.abspath(workspace)
+
+    self.num_cores = num_cores
+    self.timeout = timeout
+
+    self.fuzzers = list(self._init_fuzzers())
+    L.debug(f"Fuzzers for ensembling: {self.fuzzers}")
+
+    # given a path to a DeepState harness, provision/compile, and retrieve test bins
+    if type(target) is str:
+      self.targets = self.get_tests(self._provision(target, compiler_args))
+
+    # given a list of paths from a workspace, instantiate normally
+    elif type(target) is list:
+      self.targets = self.get_tests(target)
+
+
+  def _provision(self, test_case, compiler_args, ignore_list=None):
+    """
+    Given a testcase source, provision a workspace with appropriate target binaries.
+
+    :param test_case: path to uncompiled test case directory
+    :param compiler_args: compilation flags (ie for linking) needed to successfully compile
+    :param ignore_list: optional str of static libraries to ignore for taint analysis (see Angora frontend)
+    """
+    if not os.path.isdir(self.workspace):
+      L.info("Workspace doesn't exist. Creating.")
+      os.mkdir(self.workspace)
+
+    L.info("Provisioning test case into workspace with instrumented binaries")
+    for fuzzer in self.fuzzers:
+
+      test_name = self.workspace + "/" + test_case.split(".")[0]
+      L.debug(f"Compiling `{test_name}` for fuzzer `{fuzzer}`")
+
+      cmd_map = {
+        "compile_test": test_case,
+        "out_test_name": test_name,
+        "compiler_args": compiler_args
+      }
+
+      if type(fuzzer) is Angora:
+        cmd_map["mode"] = "llvm"
+        cmd_map["ignore_calls"] = ignore_list
+
+      fuzzer.set_args(cmd_map)
+      fuzzer.compile()
+
+    return [test for test in os.listdir(self.workspace)]
+
+
+  def _init_fuzzers(self):
+    """
+    Instantiates a "call map" with all fuzzer frontends.
+
+    TODO: feature for overriding functionality based on human interaction
+    """
+    return [subclass() for subclass in DeepStateFrontend.__subclasses__()]
+
+
+  def get_tests(self, tests):
+    """
+    Given a workspace path, retrieve testcases and map to specific fuzzer. We map
+    based on the condition that the generated test binary contains an extension
+    denoting the fuzzer name.
+
+    :param tests: list of paths to workspace with already-compiled target binaries
+    """
+
+    def get_fuzzer(test):
+      ext = test.split(".")[-1]
+      if ext in ["fast", "taint"]:
+        return "angora"
+      else:
+        return ext.lower()
+
+    fuzz_map = defaultdict(list)
+    for test in tests:
+      for fuzzer in self.fuzzers:
+        if str(fuzzer).lower() == get_fuzzer(test):
+          fuzz_map[fuzzer].append(test)
+
+    L.debug(f"Fuzzer and corresponding test cases: {fuzz_map}")
+    return fuzz_map
+
+
+  def run(self, which_test=None, exit_crash=False):
+    """
+    Bootstraps all fuzzers for ensembling with appropriate arguments,
+    and run fuzzers in parallel.
+
+    :param which_test: specifies which test from suite to analyze
+    :param exit_crash: if set, kills fuzzers once a singular crash is discovered
+    """
+
+    procs = []
+
+    for fuzzer, binary in self.targets.items():
+      fuzzer_args = {
+        "enable_sync": True,
+        "sync_cycle": 3,
+        "sync_dir": self.sync_dir,
+        "timeout": self.timeout,
+        "binary": self.workspace + "/" + binary[0],
+        "input_seeds": self.seeds,
+        "output_test_dir": "{}/{}_out".format(self.out_dir, str(fuzzer)),
+        "args": [],
+        "max_input_size": 8192,
+        "mem_limit": 50,
+        "which_test": which_test,
+      }
+
+      if type(fuzzer) is Angora:
+        fuzzer_args.update({
+          "binary": next((self.workspace + "/" + b for b in binary if ".fast" in b), None),
+          "taint_binary": next((self.workspace + "/" + b for b in binary if ".taint" in b), None),
+          "no_afl": False,
+          "mode": "llvm",
+          "no_exploration": False
+        })
+
+      elif type(fuzzer) is AFL:
+        fuzzer_args.update({
+          "parallel_mode": False,
+          "dirty_mode": False,
+          "dumb_mode": False,
+          "qemu_mode": False,
+          "crash_explore": False,
+          "dictionary": None,
+          "file": None
+        })
+
+      fuzzer.set_args(fuzzer_args)
+
+      # sets compiler and no_exec params before execution
+      if type(fuzzer) is Eclipser:
+        args = ("dotnet", True)
+      else:
+        args = (None, True)
+
+      # initialize concurrent process and add to process pool
+      p = Process(target=fuzzer.run, args=args)
+      p.start()
+      procs.append(p)
+
+    for p in procs:
+      p.join()
+
+
+  def post_process(self, global_stats=False):
+    """
+    Perform post-processing for each ensembled fuzzer.
+
+    TODO: global coverage map generation / visualization
+    """
+    for fuzzer in self.fuzzers:
+      if not global_stats:
+        if hasattr(fuzzer, "post_exec"):
+          fuzzer.post_exec()
+
+
+
+def main():
+  parser = argparse.ArgumentParser(description="DeepState Ensemble Fuzzer.")
+  test_group = parser.add_mutually_exclusive_group(required=True)
+
+  # Mutually exclusive target options
+  test_group.add_argument("--test", type=str, \
+    help="Path to test case harness for compilation and instrumentation.")
+
+  test_group.add_argument("--test_dir", type=str, \
+    help="Path to existing workspace directory with compiled and instrumented binaries.")
+
+
+  # Compilation options
+  parser.add_argument("-a", "--compiler_args", type=str, \
+    help="Compiler linker arguments for test harness, if provided as argument")
+  parser.add_argument("--ignore_calls", type=str, \
+    help="Path to static/shared libraries (colon seperated) for functions to blackbox for taint analysis.")
+
+
+  # Fuzzer-related in/output paths
+  parser.add_argument("-i", "--input_seeds", type=str, required=True, \
+    help="Path to directory with initial seed inputs for all fuzzer instances.")
+
+  parser.add_argument("-o", "--out_dir", type=str, default="out", \
+    help="Path to output directory for generated fuzzer logs and local queue (default is `out`).")
+
+  parser.add_argument("-s", "--sync_dir", type=str, default="out_sync", \
+    help="Path to shared seed synchronization directory (default is `out_sync`).")
+
+  parser.add_argument("-w", "--workspace", type=str, default="ensemble_bins", \
+    help="Path to workspace to store compiled and instrumented binaries (default is `ensemble_bins`).")
+
+  # TODO(alan): allow user to manually specify base fuzzers to implement
+
+
+  # Ensembler execution options
+  parser.add_argument("-n", "--num_cores", type=int, default=multiprocessing.cpu_count(), \
+    help="Override number of cores to use.")
+
+  parser.add_argument("--which_test", type=str, \
+    help="Which test to run (equivalent to --input_which_test).")
+
+  parser.add_argument("-t", "--timeout", type=int, default=360, \
+    help="Timeout for ensemble fuzzer in seconds (default: 360).")
+
+  parser.add_argument("--abort_on_crash", action="store_true", \
+    help="Stop ensembler when any base fuzzer returns a crash")
+
+  args = parser.parse_args()
+
+
+  if args.test_dir and (args.ignore_calls or args.compiler_args):
+    L.info("Ignoring --ignore_calls and/or --compiler_args arguments passed")
+
+  # initial path check
+  _test = args.test if not args.test_dir else args.test_dir
+  if not os.path.exists(_test):
+    print(f"Target path `{_test}` does not exist. Exiting.")
+    sys.exit(1)
+
+  # initialize target - test str if user specified a harness, or a list to already-compiled binaries
+  test = args.test if not args.test_dir else list([f for f in os.listdir(args.test_dir)])
+
+  # initialize test case to run from harness, if specified
+  which_test = args.which_test if args.which_test else None
+
+  if not os.path.isdir(args.input_seeds):
+    print(f"Input seeds directory `{args.input_seeds}` does not exist. Exiting.")
+    sys.exit(1)
+
+  if not os.path.isdir(args.out_dir):
+    print("Output directory does not exist. Creating.")
+    os.mkdir(args.out_dir)
+
+  if not os.path.isdir(args.sync_dir):
+    print("Sync directory does not exist. Creating.")
+    os.mkdir(args.sync_dir)
+  elif os.path.isdir(args.sync_dir) and len([f for f in os.listdir(args.sync_dir)]) != 0:
+    print("Sync directory exists and is not empty. Exiting.")
+    sys.exit(1)
+
+  # initialize ensembler
+  ensembler = Ensembler(test, args.input_seeds, args.out_dir, args.sync_dir,
+                        args.num_cores, args.timeout, args.workspace, args.compiler_args, args.ignore_calls)
+
+  ensembler.run(which_test, args.abort_on_crash)
+  ensembler.post_process()
+  return 0
+
+
+if __name__ == "__main__":
+  exit(main())

--- a/bin/deepstate/frontend/afl.py
+++ b/bin/deepstate/frontend/afl.py
@@ -194,11 +194,12 @@ class AFL(DeepStateFrontend):
 
 
   def reporter(self):
-    print("\nAFL Status:")
-    print("\tExecs Completed: {}".format(self.stats["execs_done"]))
-    print("\tCycle Completed: {}".format(self.stats["cycles_done"]))
-    print("\tUnique Crashes: {}".format(self.stats["unique_crashes"]))
-    print("\tUnique Hangs: {}".format(self.stats["unique_hangs"]))
+    return dict({
+        "Execs Done": self.stats["execs_done"],
+        "Cycle Completed": self.stats["cycles_done"],
+        "Unique Crashes": self.stats["unique_crashes"],
+        "Unique Hangs": self.stats["unique_hangs"],
+    })
 
 
   def _sync_seeds(self, mode, src, dest, excludes=["*.cur_input"]):

--- a/bin/deepstate/frontend/afl.py
+++ b/bin/deepstate/frontend/afl.py
@@ -33,13 +33,7 @@ class AFL(DeepStateFrontend):
 
   @classmethod
   def parse_args(cls):
-    parser = argparse.ArgumentParser(description="Use AFL as a back-end for DeepState.")
-
-    # Compilation/instrumentation support
-    compile_group = parser.add_argument_group("compilation and instrumentation arguments")
-    compile_group.add_argument("--compile_test", type=str, help="Path to DeepState test harness for compilation.")
-    compile_group.add_argument("--compiler_args", type=str, help="Linker flags (space seperated) to include for external libraries.")
-    compile_group.add_argument("--out_test_name", type=str, default="out", help="Set name of generated instrumented binary.")
+    parser = argparse.ArgumentParser(description="Use AFL as a backend for DeepState")
 
     # Execution options
     parser.add_argument("--dictionary", type=str, help="Optional fuzzer dictionary for AFL.")
@@ -66,7 +60,7 @@ class AFL(DeepStateFrontend):
     L.debug(f"Static library path: {lib_path}")
 
     if not os.path.isfile(lib_path):
-      raise RuntimeError("no AFL-instrumented DeepState static library found in {}".format(lib_path))
+      raise FrontendError("no AFL-instrumented DeepState static library found in {}".format(lib_path))
 
     flags = ["-ldeepstate_AFL"]
     if args.compiler_args:
@@ -199,7 +193,15 @@ class AFL(DeepStateFrontend):
     return stats
 
 
-  def _sync_seeds(self, mode, src, dest, excludes=["orig", ".state"]):
+  def reporter(self):
+    print("\nAFL Status:")
+    print("\tExecs Completed: {}".format(self.stats["execs_done"]))
+    print("\tCycle Completed: {}".format(self.stats["cycles_done"]))
+    print("\tUnique Crashes: {}".format(self.stats["unique_crashes"]))
+    print("\tUnique Hangs: {}".format(self.stats["unique_hangs"]))
+
+
+  def _sync_seeds(self, mode, src, dest, excludes=["*.cur_input"]):
     super()._sync_seeds(mode, src, dest, excludes=excludes)
 
 

--- a/bin/deepstate/frontend/afl.py
+++ b/bin/deepstate/frontend/afl.py
@@ -194,6 +194,9 @@ class AFL(DeepStateFrontend):
 
 
   def reporter(self):
+    """
+    Report a summarized version of statistics, ideal for ensembler output.
+    """
     return dict({
         "Execs Done": self.stats["execs_done"],
         "Cycle Completed": self.stats["cycles_done"],

--- a/bin/deepstate/frontend/angora.py
+++ b/bin/deepstate/frontend/angora.py
@@ -189,16 +189,26 @@ class Angora(DeepStateFrontend):
     """
     args = self._ARGS
     stat_file = args.output_test_dir + "/chart_stat.json"
-    with open(stat_file, "r") as handle:
-      stats = json.loads(handle.read())
+
+    if not hasattr(self, "prev_stats"):
+      self.prev_stats = None
+
+    try:
+      with open(stat_file, "r") as handle:
+        stats = json.loads(handle.read())
+        self.prev_stats = stats
+    except json.decoder.JSONDecodeError:
+      stats = self.prev_stats
+
     return stats
 
 
   def reporter(self):
-    print("\nAngora Stats:")
-    print("\tExecs Completed: {}".format(self.stats["num_exec"]))
-    print("\tUnique Crashes: {}".format(self.stats["num_crashes"]))
-    print("\tUnique Hangs: {}".format(self.stats["num_hangs"]))
+    return dict({
+      "Execs Done": self.stats["num_exec"],
+      "Unique Crashes": self.stats["num_crashes"],
+      "Unique Hangs": self.stats["num_hangs"],
+    })
 
 
 def main():

--- a/bin/deepstate/frontend/eclipser.py
+++ b/bin/deepstate/frontend/eclipser.py
@@ -125,12 +125,11 @@ class Eclipser(DeepStateFrontend):
 
   def reporter(self):
     args = self._ARGS
-    print("\nEcliper Status:")
-
     num_crashes = len([crash for crash in os.listdir(args.output_test_dir + "/crash")
                        if os.path.isfile(crash)])
-
-    print("\tUnique Crashes: {}".format(num_crashes))
+    return dict({
+        "Unique Crashes": num_crashes
+    })
 
 
 def main():

--- a/bin/deepstate/frontend/frontend.py
+++ b/bin/deepstate/frontend/frontend.py
@@ -29,6 +29,18 @@ L = logging.getLogger("deepstate.frontend")
 L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
 
 
+class AttrDict(dict):
+  """
+  Since the argparser dictates most of the attributes the frontend
+  uses to orchestrate a fuzzer, we can create a custom AttrDict that
+  enables us to access keys as attributes.
+  """
+
+  def __init__(self, *args, **kwargs):
+    super(AttrDict, self).__init__(*args, **kwargs)
+    self.__dict__ = self
+
+
 class FrontendError(Exception):
   pass
 
@@ -72,20 +84,35 @@ class DeepStateFrontend(object):
 
     # if supplied, check if compiler exists in potential_paths
     if compiler is not None:
+
       compiler_paths = [f"{path}/{compiler}" for path in potential_paths if os.path.isfile(path + '/' + compiler)]
+
       if len(compiler_paths) == 0:
 
-        # check to see if user supplied absolute path or compiler resides in PATH
+        # if not in envvar, check to see if user supplied absolute path
         if os.path.isfile(compiler):
           self.compiler = compiler
+
+        # .. or check if in $PATH before tossing exception
         else:
-          raise FrontendError(f"{compiler} does not exist as absolute path or in ${envvar}")
+          for path in os.environ["PATH"].split(os.pathsep):
+            compiler_path = os.path.join(path, compiler)
+
+            L.debug(f"Checking if `{compiler_path}` is a valid compiler path")
+            if os.path.isfile(compiler_path) and os.access(compiler_path, os.X_OK):
+              self.compiler = compiler_path
+              break
 
       # use first compiler executable if multiple exists
-      self.compiler = compiler_paths[0]
+      else:
+        self.compiler = compiler_paths[0]
 
-      L.debug(f"Initialized compiler: {self.compiler}")
 
+    # toss exception if compiler could not be found
+    if not hasattr(self, "compiler"):
+      raise FrontendError(f"{compiler} does not exist as absolute path, or in ${envvar} or $PATH")
+
+    L.debug(f"Initialized compiler: {self.compiler}")
 
     # in case name supplied as `bin/fuzzer`, strip executable name
     if '/' in fuzzer_name:
@@ -100,6 +127,10 @@ class DeepStateFrontend(object):
 
     self._start_time = int(time.time())
     self._on = False
+
+
+  def __repr__(self):
+    return "{}".format(self.__class__.__name__)
 
 
   def print_help(self):
@@ -197,22 +228,32 @@ class DeepStateFrontend(object):
     cmd_args = [arg for arg in cmd_args if arg is not None]
 
     L.debug(f"Fuzzer arguments: `{str(cmd_args)}`")
-
     return cmd_args
 
 
-  def run(self, compiler=None):
+  def reporter(self):
+    """
+    Provides an interface for fuzzers to output important statistics during an ensemble
+    cycle. This ensure that fuzzer outputs don't clobber STDOUT, and that users can gain
+    insight during ensemble run.
+    """
+    return NotImplementedError("Must implement in frontend subclass.")
+
+
+  def run(self, compiler=None, no_exec=False):
     """
     Spawns the fuzzer by taking the self.cmd property and initializing a command in a list
     format for subprocess.
 
     :param compiler: if necessary, a compiler that is invoked before fuzzer executable (ie `dotnet`)
+    :param no_exec: skips pre- and post-processing steps during execution
     """
     args = self._ARGS
 
-    # call pre_exec for any checks/inits before execution
-    L.info("Calling pre_exec before fuzzing")
-    self.pre_exec()
+    # call pre_exec for any checks/inits before execution.
+    if not no_exec:
+      L.info("Calling pre_exec before fuzzing")
+      self.pre_exec()
 
     # initialize cmd from property or throw exception
     if hasattr(self, "cmd") or isinstance(getattr(type(self), "cmd", None), property):
@@ -224,46 +265,40 @@ class DeepStateFrontend(object):
     if compiler:
       command.insert(0, compiler)
 
-    L.info(f"Executing command `{str(command)}` in {args.jobs} fuzzer(s)")
+    L.info(f"Executing command `{str(command)}`")
 
     # exec fuzzer
     L.info(f"Fuzzer start time: {self._start_time}")
     self._on = True
 
-    # TODO(alan): output to standardized logger with uniform pretty-printing
-    def output_reader(proc):
-      for line in iter(proc.stdout.readline, b''):
-        print("{}".format(line.decode("utf-8")), end='')
+
+    # if we are syncing seeds, we background the AFL process but still process output
+    # to the foreground
+    if args.enable_sync:
+      self.proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+      L.info(f"Starting fuzzer with seed synchronization with PID `{self.proc.pid}`")
+    else:
+      self.proc = subprocess.Popen(command)
+      L.info(f"Starting fuzzer normally with PID `{self.proc.pid}`")
+
 
     try:
 
-      # if we are syncing seeds, we background the AFL process but still process output
-      # to the foreground, while handling seed synchronization in a loop
       if args.enable_sync:
-        self.proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-        t = threading.Thread(target=output_reader, args=(self.proc,))
-        t.start()
 
         # do not ensemble as fuzzer initializes
         time.sleep(5)
-
         self.sync_count = 0
 
-        L.info(f"Starting fuzzer with seed synchronization with PID `{self.proc.pid}`")
         while self._is_alive():
-          L.info(f"Performing sync cycle {self.sync_count}")
+          L.debug(f"{self.name} - Performing sync cycle {self.sync_count}")
           time.sleep(args.sync_cycle)
           self.ensemble()
+          self.reporter()
           self.sync_count += 1
 
-
-      # if not syncing, start regular foreground child process with regular thread for consistency
+      # if not syncing, start regular foreground child process
       else:
-        self.proc = subprocess.Popen(command)
-        t = threading.Thread()
-        t.start()
-
-        L.info(f"Starting fuzzer normally with PID `{self.proc.pid}`")
         self.proc.communicate()
 
 
@@ -273,15 +308,23 @@ class DeepStateFrontend(object):
     except KeyboardInterrupt:
       self._kill()
 
-    t.join()
+    finally:
+      self._kill()
 
-    self.exec_time = round(time.time() - self._start_time, 2)
+    if not args.enable_sync:
+      self.exec_time = round(time.time() - self._start_time, 2)
+
+    # five second delay due to ensemble wait, subtract from time
+    else:
+      self.exec_time = round(time.time() - self._start_time, 2) - 5
+
     L.info(f"Fuzzer exec time: {self.exec_time}s")
 
     # do post-fuzz operations
-    if hasattr(self, "post_exec") and callable(getattr(self, "post_exec")):
-      L.info("Calling post-exec for fuzzer post-processing")
-      self.post_exec()
+    if not no_exec:
+      if hasattr(self, "post_exec") and callable(getattr(self, "post_exec")):
+        L.info("Calling post-exec for fuzzer post-processing")
+        self.post_exec()
 
 
   def _is_alive(self):
@@ -310,7 +353,12 @@ class DeepStateFrontend(object):
       raise FrontendError("Attempted to kill non-running PID.")
 
     self.proc.terminate()
-    self.proc.wait()
+    try:
+      self.proc.wait(timeout=0.5)
+      L.info(f"Fuzzer subprocess exited with `{self.proc.returncode}`")
+    except subprocess.TimeoutExpired:
+      raise FrontendError("Subprocess could not terminate in time")
+
     self._on = False
 
 
@@ -361,6 +409,14 @@ class DeepStateFrontend(object):
 
   @staticmethod
   def _queue_len(queue_path):
+    """
+    Helper that checks the number of seeds in queue, returns 0 if path doesn't
+    exist yet.
+
+    :param queue_path: path to queue (ie AFL_out/queue/)
+    """
+    if not os.path.exists(queue_path):
+      return 0
     return len([path for path in os.listdir(queue_path)])
 
 
@@ -389,8 +445,7 @@ class DeepStateFrontend(object):
       self._sync_seeds("PUSH", local_queue, global_queue)
       return
 
-    # get seeds from AFL to global queue, rsync will deal with duplicates
-    # TODO: rename sync seeds to arbitrary filenames in queue
+    # get seeds from local to global queue, rsync will deal with duplicates
     self._sync_seeds("GET", global_queue, local_queue)
 
     # push seeds from global queue to local, rsync will deal with duplicates
@@ -398,6 +453,22 @@ class DeepStateFrontend(object):
 
 
   _ARGS = None
+
+  def set_args(self, target_dict):
+    """
+    Helper method that allows a user to manually instantiate _ARGS as an AttrDict for
+    attribute accessibility. Optimal when accessing frontends without parse_args instantiation.
+    """
+
+    if type(self._ARGS) is argparse.ArgumentParser:
+      raise FrontendError("Arguments already parsed with parse_args.")
+
+    if self._ARGS is None:
+      self._ARGS = AttrDict()
+
+    for key, value in target_dict.items():
+      self._ARGS.update({key: value})
+
 
   @classmethod
   def parse_args(cls):
@@ -415,27 +486,32 @@ class DeepStateFrontend(object):
       L.debug("Using previously initialized parser")
       parser = cls.parser
     else:
-      parser = argparse.ArgumentParser(
-        description="Use fuzzer as back-end for DeepState.")
+      parser = argparse.ArgumentParser(description="Use {} fuzzer as a backend for DeepState".format(str(cls)))
+
+    # Compilation/instrumentation support, only if COMPILER is set
+    if cls.COMPILER:
+      compile_group = parser.add_argument_group("compilation and instrumentation arguments")
+      compile_group.add_argument("--compile_test", type=str, help="Path to DeepState test harness for compilation.")
+      compile_group.add_argument("--compiler_args", type=str, help="Linker flags (space seperated) to include for external libraries.")
+      compile_group.add_argument("--out_test_name", type=str, default="out", help="Set name of generated instrumented binary.")
 
     # Target binary (not required, as we enforce manual checks in pre_exec)
     parser.add_argument("binary", nargs="?", type=str, help="Path to the test binary to run.")
 
     # Input/output workdirs
     parser.add_argument("-i", "--input_seeds", type=str, help="Directory with seed inputs.")
-    parser.add_argument("-o", "--output_test_dir", type=str, default=f"out", help="Directory where tests will be saved.")
+    parser.add_argument("-o", "--output_test_dir", type=str, default="{}_out".format(str(cls())), help="Directory where tests will be saved.")
 
     # Fuzzer execution options
     parser.add_argument("-t", "--timeout", type=int, default=3600, help="How long to fuzz.")
     parser.add_argument("-s", "--max_input_size", type=int, default=8192, help="Maximum input size.")
-    parser.add_argument("-j", "--jobs", type=int, default=1, help="How many worker processes to spawn.")
 
     # Parallel / Ensemble Fuzzing
     parser.add_argument("--enable_sync", action="store_true", help="Enable seed synchronization.")
     parser.add_argument("--sync_dir", type=str, default="out_sync", help="Directory for seed synchronization.")
     parser.add_argument("--sync_cycle", type=int, default=5, help="Time between sync cycle.")
     parser.add_argument("--sync_crashes", action="store_true", help="Sync crashes between local and global queue.")
-    parser.add_argument("--sync_hangs", action="store_true", help="Sync hanging input between local and global queue.")
+    parser.add_argument("--sync_hangs", action="store_true", help="Sync hanging inputs between local and global queue.")
 
     # Miscellaneous options
     parser.add_argument("--fuzzer_help", action="store_true", help="Show fuzzer command line options.")

--- a/bin/deepstate/frontend/frontend.py
+++ b/bin/deepstate/frontend/frontend.py
@@ -299,7 +299,8 @@ class DeepStateFrontend(object):
           # call ensemble to perform seed synchronization
           self.ensemble()
 
-          # call subclass reporter method to output useful stats
+          # if sync_out argument set, output individual fuzzer statistics
+          # rather than have our ensembler report global stats
           if args.sync_out:
             print(f"\n{self.name} Fuzzer Stats\n")
             for head, stat in self.reporter().items():

--- a/bin/setup.py.in
+++ b/bin/setup.py.in
@@ -37,6 +37,7 @@ setuptools.setup(
             'deepstate-angr = deepstate.main_angr:main',
             'deepstate-manticore = deepstate.main_manticore:main',
             'deepstate-reduce = deepstate.reducer:main',
+            'deepstate-ensembler = deepstate.ensembler:main',
             'deepstate-afl = deepstate.frontend.afl:main',
             'deepstate-eclipser = deepstate.frontend.eclipser:main',
             'deepstate-angora = deepstate.frontend.angora:main'


### PR DESCRIPTION
DeepState ensembler mode! Currently works as so:

```
# with an uncompiled DeepState harness
$ deepstate-ensembler --test Crash.cpp -i local_seeds

# ... or with a pre-existing "workspace" of tests 
$ tree my_workspace
my_workspace
├── Crash.afl
├── Crash.eclipser
├── Crash.fast
└── Crash.taint

$ deepstate --test_dir my_workspace -i local_seeds
```

## TODOs

* [x] Better output - all fuzzers fight for stdout, make a better output mechanism for clarity (ie `afl-whatsup`)
* [ ] Post-processing - output useful stats from ensemble run, perform crash de-dup/triage, etc.
* [x] More robust CLI parsing (ie include `--ignore_calls` for Angora)
* [x] Documentation!