### PR TITLE
Fallback to traditional imports for linter

### DIFF
--- a/bin/deepstate/ensembler.py
+++ b/bin/deepstate/ensembler.py
@@ -26,14 +26,17 @@ from multiprocessing import Process
 from collections import defaultdict
 
 from .frontend import DeepStateFrontend
+from .frontend.afl import AFL
+from .frontend.angora import Angora
+from .frontend.eclipser import Eclipser
 
-
-# dynamically imports any known subclass of DeepStateFrontend
-# TODO(alan): refactor with any safe sanity checks?
+"""
+TODO: safer support for dynamic subclass importing
 for subclass in DeepStateFrontend.__subclasses__():
   __import__(subclass.__module__, globals(), locals(), [subclass.__name__])
   globals().update({subclass.__name__:
                     getattr(sys.modules[subclass.__module__], subclass.__name__)})
+"""
 
 
 L = logging.getLogger("deepstate.ensembler")


### PR DESCRIPTION
Using dynamic subclass imports as part of the ensembler may not be entirely safe, so let's stick with traditional imports with the sparse number of fuzzer frontends we have now, and think about a different way we can import `DeepStateFrontend` subclasses without hacky magic. This way we also don't break any linters that aren't able to find the subclasses.