### PR TITLE
fix libfuzzer not working with no seeds (they aren't required)

### DIFF
--- a/bin/deepstate/frontend/eclipser.py
+++ b/bin/deepstate/frontend/eclipser.py
@@ -72,6 +72,12 @@ class Eclipser(DeepStateFrontend):
       print("Creating output directory.")
       os.mkdir(out)
 
+    seeds = args.input_seeds
+    if seeds:
+      if os.path.exists(seeds):
+        if len([name for name in os.listdir(seeds)]) == 0:
+          raise FrontendError(f"Seeds path specified but none present in directory.")
+
 
   @property
   def cmd(self):

--- a/bin/deepstate/frontend/libfuzzer.py
+++ b/bin/deepstate/frontend/libfuzzer.py
@@ -79,9 +79,10 @@ class LibFuzzer(DeepStateFrontend):
     seeds = args.input_seeds
 
     # check if seeds are present if specified
-    if os.path.exists(seeds):
-      if len([name for name in os.listdir(seeds)]) == 0:
-        raise FrontendError(f"Seeds path specified but none present in directory.")
+    if seeds:
+      if os.path.exists(seeds):
+        if len([name for name in os.listdir(seeds)]) == 0:
+          raise FrontendError(f"Seeds path specified but none present in directory.")
 
 
   @property


### PR DESCRIPTION
Simple fix, it currently checks the path if seeds are not specified, which breaks libfuzzer without seeds