### PR TITLE
Add support for DeepState_InputPath

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -192,6 +192,21 @@ if (BUILD_AFL)
    target_link_libraries(BoringDisabled_AFL deepstate_AFL)
 endif()
 
+add_executable(InputPath InputPath.cpp)
+target_link_libraries(InputPath deepstate)
+
+if (BUILD_LIBFUZZER)
+   add_executable(InputPath_LF InputPath.cpp)
+   target_link_libraries(InputPath_LF deepstate_LF)
+   target_link_libraries (InputPath_LF "-fsanitize=fuzzer,undefined")
+   set_target_properties(InputPath_LF PROPERTIES COMPILE_DEFINITIONS "LIBFUZZER")
+endif()
+
+if (BUILD_AFL)
+   add_executable(InputPath_AFL InputPath.cpp)
+   target_link_libraries(InputPath_AFL deepstate_AFL)
+endif()
+
 if (NOT APPLE)
   add_executable(Squares Squares.c)
   target_link_libraries(Squares deepstate)

--- a/examples/InputPath.cpp
+++ b/examples/InputPath.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <map>
+#include <sstream>
+#include <fstream>
+#include <deepstate/DeepState.hpp>
+
+using namespace deepstate;
+
+
+/* Represents a simple pedagogical database-like structure */
+typedef struct Datastore {
+  int id;
+  char *data;
+} Datastore;
+
+
+void write_file(const char *path, Datastore& obj) {
+  std::ofstream out;
+  out.open(path, std::ios::binary);
+  out.write(reinterpret_cast<char*>(&obj), sizeof(obj));
+  out.close();
+}
+
+
+/* Represents our higher-level parser function being tested, which in this case takes a path rather
+ * than a primitive type, ie a char ptr, and deserializes it into a proper data structure. */
+Datastore parse_file(const char * path) {
+  Datastore obj;
+  std::ifstream read_file;
+  read_file.open(path, std::ios::binary);
+  read_file.read(reinterpret_cast<char*>(&obj), sizeof(obj));
+  read_file.close();
+  return obj;
+}
+
+
+/* A hacky concrete test that writes an instantiated data structure to the specified file.
+ * Run this test in order to generate an input seed for analyzing InputPath_Deserialize */
+TEST(InputPath, Serialize) {
+
+  const char *path = DeepState_InputPath(NULL);
+  LOG(INFO) << "Input path to write to: " << path;
+
+  Datastore obj;
+
+  obj.id = 0;
+  obj.data = (char *) "Admin";
+
+  LOG(INFO) << "Serializing and writing to path";
+  write_file(path, obj);
+}
+
+
+/* Actual test to analyze. Be sure to fuzz this test rather than a symex engine. */
+TEST(InputPath, Deserialize) {
+
+  const char *path = DeepState_InputPath(NULL);
+  LOG(INFO) << "Input path to read from: " << path;
+
+  Datastore store = parse_file(path);
+
+  ASSERT(store.id == 0) << "initial user does not have a 0 id";
+  ASSERT(store.data != "Admin") << "cannot have admin username";
+}

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -200,6 +200,9 @@ extern const char *DeepState_ConcretizeCStr(const char *begin);
 /* Allocate and return a pointer to `num_bytes` symbolic bytes. */
 extern void *DeepState_Malloc(size_t num_bytes);
 
+/* Returns the path to a testcase without parsing to any aforementioned types */
+extern const char *DeepState_InputPath(char *testcase_path);
+
 #define DEEPSTATE_MAKE_SYMBOLIC_ARRAY(Tname, tname) \
     DEEPSTATE_INLINE static \
     tname *DeepState_Symbolic ## Tname ## Array(size_t num_elms) { \
@@ -870,7 +873,6 @@ static int DeepState_RunSingleSavedTestDir(void) {
       DeepState_LogFormat(DeepState_LogWarning,
 			  "No test specified, defaulting to first test defined (%s)",
 			  test->test_name);
-	;
       break;
     }
   }
@@ -909,13 +911,12 @@ static int DeepState_RunSingleSavedTestDir(void) {
         DeepState_RunSavedTestCase(test, FLAGS_input_test_files_dir, dp->d_name);
 
       if ((result == DeepState_TestRunFail) || (result == DeepState_TestRunCrash)) {
-	if (FLAGS_abort_on_fail) {
-	  DeepState_HardCrash();
-	}
-	if (FLAGS_exit_on_fail) {
-	  exit(255); // Terminate the testing
-	}
-
+        if (FLAGS_abort_on_fail) {
+          DeepState_HardCrash();
+        }
+        if (FLAGS_exit_on_fail) {
+          exit(255); // Terminate the testing
+        }
         num_failed_tests++;
       }
     }


### PR DESCRIPTION
See https://github.com/trailofbits/deepstate/issues/238 for more details.

PR adds support for `DeepState_InputPath`, enabling a user to specify a path name to store rather read and parsed to a primitive type. Also includes a WIP test that implements a serializable data structure for analysis with the new function.