### PR TITLE
Add DeepState_MemScrub function

### DIFF
--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -197,6 +197,9 @@ extern const char *DeepState_ConcretizeCStr(const char *begin);
 /* Allocate and return a pointer to `num_bytes` symbolic bytes. */
 extern void *DeepState_Malloc(size_t num_bytes);
 
+/* Portable and architecture-independent memory scrub without dead store elimination. */
+extern void *DeepState_MemScrub(void *pointer, size_t data_size);
+
 #define DEEPSTATE_MAKE_SYMBOLIC_ARRAY(Tname, tname) \
     DEEPSTATE_INLINE static \
     tname *DeepState_Symbolic ## Tname ## Array(size_t num_elms) { \
@@ -517,7 +520,7 @@ static void DeepState_InitInputFromFile(const char *path) {
   }
 
   /* Reset the input buffer and reset the index. */
-  memset((void *) DeepState_Input, 0, sizeof(DeepState_Input));
+  DeepState_MemScrub((void *) DeepState_Input, sizeof(DeepState_Input));
   DeepState_InputIndex = 0;
 
   size_t count = fread((void *) DeepState_Input, 1, to_read, fp);

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -295,6 +295,16 @@ void *DeepState_Malloc(size_t num_bytes) {
   return data;
 }
 
+/* Portable and architecture-independent memory scrub without dead store elimination. */
+void *DeepState_MemScrub(void *pointer, size_t data_size) {
+  volatile unsigned char *p = pointer;
+  while (data_size--) {
+    *p++ = 0;
+  }
+  return pointer;
+}
+
+
 DEEPSTATE_NOINLINE int DeepState_One(void) {
   return 1;
 }
@@ -897,7 +907,7 @@ extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     }
   }
 
-  memset((void *) DeepState_Input, 0, sizeof(DeepState_Input));
+  DeepState_MemScrub((void *) DeepState_Input, sizeof(DeepState_Input));
   DeepState_InputIndex = 0;
 
   memcpy((void *) DeepState_Input, (void *) Data, Size);

--- a/src/lib/Log.c
+++ b/src/lib/Log.c
@@ -48,7 +48,7 @@ static const char *DeepState_LogLevelStr(enum DeepState_LogLevel level) {
     case DeepState_LogDebug:
       return "DEBUG";
     case DeepState_LogTrace:
-      return "TRACE";      
+      return "TRACE";
     case DeepState_LogInfo:
       return "INFO";
     case DeepState_LogWarning:
@@ -80,7 +80,7 @@ void DeepState_Log(enum DeepState_LogLevel level, const char *str) {
       (level < FLAGS_min_log_level)) {
     return;
   }
-  memset(DeepState_LogBuf, 0, DeepState_LogBufSize);
+  DeepState_MemScrub(DeepState_LogBuf, DeepState_LogBufSize);
   snprintf(DeepState_LogBuf, DeepState_LogBufSize, "%s: %s\n",
            DeepState_LogLevelStr(level), str);
   fputs(DeepState_LogBuf, stderr);
@@ -196,7 +196,7 @@ int vfprintf(FILE *file, const char *format, va_list args) {
 	DeepState_LogVFormat(DeepState_LogInfo, format, args);
       }
     } else {
-      DeepState_LogVFormat(DeepState_LogExternal, format, args);      
+      DeepState_LogVFormat(DeepState_LogExternal, format, args);
     }
   */
   return 0;

--- a/src/lib/Stream.c
+++ b/src/lib/Stream.c
@@ -46,7 +46,7 @@ struct DeepState_StreamFormatOptions {
 /* Stream type that accumulates formatted data to be printed. This loosely
  * mirrors C++ I/O streams, not because I/O streams are good, but instead
  * because the ability to stream in data to things like the C++-backed
- * `ASSERT` and `CHECK` macros is really nice. */ 
+ * `ASSERT` and `CHECK` macros is really nice. */
 struct DeepState_Stream {
   int size;
   struct DeepState_StreamFormatOptions options;
@@ -276,7 +276,7 @@ void DeepState_StreamDouble(enum DeepState_LogLevel level, double val) {
 void DeepState_ClearStream(enum DeepState_LogLevel level) {
   struct DeepState_Stream *stream = &(DeepState_Streams[level]);
   if (stream->size) {
-    memset(stream->message, 0, DeepState_StreamSize);
+    DeepState_MemScrub(stream->message, DeepState_StreamSize);
     stream->size = 0;
   }
 }
@@ -295,7 +295,7 @@ void DeepState_LogStream(enum DeepState_LogLevel level) {
 /* Reset the formatting in a stream. */
 void DeepState_StreamResetFormatting(enum DeepState_LogLevel level) {
   struct DeepState_Stream *stream = &(DeepState_Streams[level]);
-  memset(&(stream->options), 0, sizeof(stream->options));
+  DeepState_MemScrub(&(stream->options), sizeof(stream->options));
 }
 
 static int DeepState_NumLsInt64BitFormat = 2;


### PR DESCRIPTION
Fixes https://github.com/trailofbits/deepstate/issues/243

Adds API support for `DeepState_MemScrub`, which is a native memory scrubbing function that zeroes out an input set as a volatile pointer, ie

```cpp
DeepState_MemScrub((void *) DeepState_Input, sizeof(DeepState_Input));
```