### PR TITLE
Fixes double ranges (#249)

### DIFF
--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -396,11 +396,15 @@ float DeepState_FloatInRange(float low, float high) {
   if (low > high) {
     return DeepState_FloatInRange(high, low);
   }
-  if ((low < 0.0) && (high > 0.0)) { // Trick below doesn't work across sign change
-    if (DeepState_Bool()) {
-      return DeepState_FloatInRange(low, -0.0);
+  if (low < 0.0) { // Handle negatives differently
+    if (high > 0.0) {
+      if (DeepState_Bool()) {
+	return -(DeepState_FloatInRange(0.0, -low));
+      } else {
+	return DeepState_FloatInRange(0.0, high);
+      }
     } else {
-      return DeepState_FloatInRange(0.0, high);
+      return -(DeepState_FloatInRange(-high, -low));
     }
   }
   int32_t int_v = DeepState_IntInRange(*(int32_t *)&low, *(int32_t *)&high);
@@ -411,11 +415,15 @@ double DeepState_DoubleInRange(double low, double high) {
   if (low > high) {
     return DeepState_DoubleInRange(high, low);
   }
-  if ((low < 0.0) && (high > 0.0)) { // Trick below doesn't work across sign change
-    if (DeepState_Bool()) {
-      return DeepState_DoubleInRange(low, -0.0);
+  if (low < 0.0) { // Handle negatives differently
+    if (high > 0.0) {
+      if (DeepState_Bool()) {
+	return -(DeepState_DoubleInRange(0.0, -low));
+      } else {
+	return DeepState_DoubleInRange(0.0, high);
+      }
     } else {
-      return DeepState_DoubleInRange(0.0, high);
+      return -(DeepState_DoubleInRange(-high, -low));
     }
   }
   int64_t int_v = DeepState_Int64InRange(*(int64_t *)&low, *(int64_t *)&high);


### PR DESCRIPTION
Confidence in this solution: pretty high based on

`INFO: Done fuzzing! Ran 6196018 tests (20653 tests/second) with 0 failed/6189781 passed/6237 abandoned tests`

for

```
TEST(Double, Ranges) {
  double low = DeepState_Double();
  assume (!isnan(low));
  double high = DeepState_Double();
  assume (!isnan(high));
  if (low > high) {
    double temp = low;
    low = high;
    high = temp;
  }
  double v = DeepState_DoubleInRange(low, high);
  assume (!isnan(v));
  printf ("BETWEEN %lf and %lf = %lf\n", low, high, v);
  ASSERT (v >= low) << v << " < " << low;
  ASSERT (v <= high) << v << " > " << high;
}

```

In addition to passing the tests, checked that a 0.0-1.0 distribution seems to produce values over the whole range, albeit VERY skewed towards 0.0 (see issue #248)