### PR TITLE
Fix error-handling when process preemptively dies in front-end API

### DIFF
--- a/bin/deepstate/frontend/frontend.py
+++ b/bin/deepstate/frontend/frontend.py
@@ -379,8 +379,11 @@ class DeepStateFrontend(object):
       stdout, stderr = self.proc.communicate()
       if self.proc.returncode != 0:
         self._kill()
-        err = stdout if stderr is None else stderr
-        raise FrontendError(f"{self.fuzzer} run interrupted with non-zero return status. Error: {err.decode('utf-8')}")
+        if self.enable_sync:
+          err = stdout if stderr is None else stderr
+          raise FrontendError(f"{self.fuzzer} run interrupted with non-zero return status. Message: {err.decode('utf-8')}")
+        else:
+          raise FrontendError(f"{self.fuzzer} run interrupted with non-zero return status. Error code: {self.proc.returncode}")
 
       # invoke ensemble if seed synchronization option is set
       if self.enable_sync:


### PR DESCRIPTION
`subprocess.Popen` doesn't return anything in the `(stdout, stderr)` tuple if `subprocess.PIPE` is not set for the `stdout` and `stderr` parameters, which is only done for ensemble mode in order to "background" the fuzzer process. This adds some error-handling checks to properly return either the exit code for a foregrounded process, or the error message from a backgrounded process.