### PR TITLE
Clean up swarm testing support (#279)

### DIFF
--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -108,7 +108,7 @@ extern uint32_t DeepState_InputIndex;
 extern uint32_t DeepState_SwarmConfigsIndex;
 
 /* Function to return a swarm configuration. */
-extern struct DeepState_SwarmConfig* DeepState_GetSwarmConfig(unsigned fcount, const char* file, unsigned line);
+extern struct DeepState_SwarmConfig* DeepState_GetSwarmConfig(unsigned fcount, const char* file, unsigned line, int mix);
 
 /* Return a symbolic value of a given type. */
 extern int DeepState_Bool(void);


### PR DESCRIPTION
This addresses #279 and makes it easy to compile with different OneOf interpretations without rewriting code.  Default is still normal OneOf, since swarm seems to be:

- really good for brute force fuzzing
- possibly either not needed or harmful for more powerful fuzzers

Not sure about point 2 (quite sure about point 1), needs more experimentation.  Eclipser can probably get stuck "solving" the swarm config, which is a bad idea.