### PR TITLE
Fix broken test execution features in frontend

### DIFF
--- a/bin/deepstate/core/base.py
+++ b/bin/deepstate/core/base.py
@@ -78,7 +78,7 @@ class AnalysisBackend(object):
         help="Set name of generated instrumented binary (default is `out.{FUZZER}`).")
 
       compile_group.add_argument("--no_exit_compile", action="store_true",
-        help="Continue execution after compiling a harness (set as default when input is a configuration).")
+        help="Continue execution after compiling a harness (set as default if `--config` is set).")
 
     # Target binary (not required, since user may pass in source for compilation)
     parser.add_argument("binary", nargs="?", type=str,
@@ -94,8 +94,12 @@ class AnalysisBackend(object):
       help="Configuration file to be consumed instead of arguments.")
 
     parser.add_argument(
-      "-t", "--timeout", default=240, type=int,
-      help="Time to kill analysis workers, in seconds (default 240).")
+      "-t", "--timeout", default=0, type=int,
+      help="Time to kill analysis worker processes, in seconds (default is 0 for none).")
+
+    parser.add_argument(
+      "-w", "--num_workers", default=1, type=int,
+      help="Number of worker jobs to spawn for analysis (default is 1).")
 
 
     # DeepState-related options

--- a/bin/deepstate/core/symex.py
+++ b/bin/deepstate/core/symex.py
@@ -125,10 +125,6 @@ class SymexFrontend(AnalysisBackend):
         description="Symbolically execute unit tests with {}".format(cls.NAME))
 
     parser.add_argument(
-        "--num_workers", default=1, type=int,
-        help="Number of workers to spawn for testing and test generation.")
-
-    parser.add_argument(
         "--take_over", action='store_true',
         help="Explore the program starting at the `TakeOver` hook.")
 

--- a/bin/deepstate/executors/fuzz/afl.py
+++ b/bin/deepstate/executors/fuzz/afl.py
@@ -36,18 +36,36 @@ class AFL(FuzzerFrontend):
     parser = argparse.ArgumentParser(description="Use AFL as a backend for DeepState")
 
     # Execution options
-    parser.add_argument("--dictionary", type=str, help="Optional fuzzer dictionary for AFL.")
-    parser.add_argument("--mem_limit", type=int, default=50, help="Child process memory limit in MB (default is 50).")
-    parser.add_argument("--file", type=str, help="Input file read by fuzzed program, if any.")
+    parser.add_argument("--dictionary", type=str,
+      help="Optional fuzzer dictionary for AFL.")
+
+    parser.add_argument("--run_timeout", type=int, default=50,
+      help="Timeout for each instance of a run in ms (default is 50ms).")
+
+    parser.add_argument("--mem_limit", type=int, default=50,
+      help="Child process memory limit in MB (default is 50).")
+
+    parser.add_argument("--file", type=str,
+      help="Input file read by fuzzed program, if any.")
+
 
     # AFL execution modes
-    parser.add_argument("--dirty_mode", action="store_true", help="Fuzz without deterministic steps.")
-    parser.add_argument("--dumb_mode", action="store_true", help="Fuzz without instrumentation.")
-    parser.add_argument("--qemu_mode", action="store_true", help="Fuzz with QEMU mode.")
-    parser.add_argument("--crash_explore", action="store_true", help="Fuzz with crash exploration.")
+    parser.add_argument("--dirty_mode", action="store_true",
+      help="Fuzz without deterministic steps.")
+
+    parser.add_argument("--dumb_mode", action="store_true",
+      help="Fuzz without instrumentation.")
+
+    parser.add_argument("--qemu_mode", action="store_true",
+      help="Fuzz with QEMU mode.")
+
+    parser.add_argument("--crash_explore", action="store_true",
+      help="Fuzz with crash exploration.")
+
 
     # Misc. post-processing
-    parser.add_argument("--post_stats", action="store_true", help="Output post-fuzzing stats.")
+    parser.add_argument("--post_stats", action="store_true",
+      help="Output post-fuzzing stats.")
 
     cls.parser = parser
     return super(AFL, cls).parse_args()
@@ -98,13 +116,15 @@ class AFL(FuzzerFrontend):
   def cmd(self):
     cmd_dict = {
       "-o": self.output_test_dir,
-      "-t": str(self.timeout),
       "-m": str(self.mem_limit)
     }
 
     # since this is optional for AFL's dumb fuzzing
     if self.input_seeds:
       cmd_dict["-i"] = self.input_seeds
+
+    if self.run_timeout:
+      cmd_dict["-t"] = str(self.run_timeout)
 
     # check if we are using one of AFL's many "modes"
     if self.dirty_mode:


### PR DESCRIPTION
Fixes instances where certain frontend executor features did not work and were not properly implemented

* Multiprocessing support for `--num_workers` for fuzzers
* Worker process timeout with `--timeout`
* Fix frontends to work with options and align with proper and concise style