### PR TITLE
Frontend fixing

### DIFF
--- a/bin/deepstate/__init__.py
+++ b/bin/deepstate/__init__.py
@@ -4,7 +4,7 @@ import logging
 from sys import exit
 
 
-class DeepStateLogger(logging.getLoggerClass()):
+class DeepStateLogger(logging.getLoggerClass()): # type: ignore
     def __init__(self, name: str) -> None:
         logging.Logger.__init__(self, name=name)
         self.trace = functools.partial(self.log, 15) # type: ignore
@@ -46,7 +46,7 @@ LOG_LEVEL_INT_TO_LOGGER = {
   LOG_LEVEL_CRITICAL: logger.critical
 }
 
-log_level_from_env: str = os.environ.get("DEEPSTATE_LOG", 2)
+log_level_from_env: str = os.environ.get("DEEPSTATE_LOG", "2")
 try:
   logger.setLevel(LOG_LEVEL_INT_TO_STR[int(log_level_from_env)])
 except ValueError:

--- a/bin/deepstate/__init__.py
+++ b/bin/deepstate/__init__.py
@@ -50,11 +50,12 @@ log_level_from_env: str = os.environ.get("DEEPSTATE_LOG", "2")
 try:
   logger.setLevel(LOG_LEVEL_INT_TO_STR[int(log_level_from_env)])
 except ValueError:
-  print(f"$DEEPSTATE_LOG contains invalid value `{log_level_from_env}`, "
-        "should be int in 0-6 (debug, trace, info, warning, error, external, critical).")
+  print("$DEEPSTATE_LOG contains invalid value `%s`, "
+        "should be int in 0-6 (debug, trace, info, warning, error, external, critical).",
+        log_level_from_env)
   exit(1)
 except KeyError:
-  print(f"$DEEPSTATE_LOG is in invalid range, should be in 0-6 "
+  print("$DEEPSTATE_LOG is in invalid range, should be in 0-6 "
         "(debug, trace, info, warning, error, external, critical).")
   exit(1)
 

--- a/bin/deepstate/__init__.py
+++ b/bin/deepstate/__init__.py
@@ -1,0 +1,63 @@
+import os
+import functools
+import logging
+from sys import exit
+
+
+class DeepStateLogger(logging.getLoggerClass()):
+    def __init__(self, name: str) -> None:
+        logging.Logger.__init__(self, name=name)
+        self.trace = functools.partial(self.log, 15) # type: ignore
+        self.external = functools.partial(self.log, 45) # type: ignore
+
+
+logging.basicConfig()
+logging.addLevelName(15, "TRACE")
+logging.addLevelName(45, "EXTERNAL")
+logging.setLoggerClass(DeepStateLogger)
+
+logger = logging.getLogger(__name__)
+
+LOG_LEVEL_DEBUG = 0
+LOG_LEVEL_TRACE = 1
+LOG_LEVEL_INFO = 2
+LOG_LEVEL_WARNING = 3
+LOG_LEVEL_ERROR = 4
+LOG_LEVEL_EXTERNAL = 5
+LOG_LEVEL_CRITICAL = 6
+
+LOG_LEVEL_INT_TO_STR = {
+  LOG_LEVEL_DEBUG: logging.DEBUG,
+  LOG_LEVEL_TRACE: logging.getLevelName(15),
+  LOG_LEVEL_INFO: logging.INFO,
+  LOG_LEVEL_WARNING: logging.WARNING,
+  LOG_LEVEL_ERROR: logging.ERROR,
+  LOG_LEVEL_EXTERNAL: logging.getLevelName(45),
+  LOG_LEVEL_CRITICAL: logging.CRITICAL
+}
+
+LOG_LEVEL_INT_TO_LOGGER = {
+  LOG_LEVEL_DEBUG: logger.debug,
+  LOG_LEVEL_TRACE: logger.trace, # type: ignore
+  LOG_LEVEL_INFO: logger.info,
+  LOG_LEVEL_WARNING: logger.warning,
+  LOG_LEVEL_ERROR: logger.error,
+  LOG_LEVEL_EXTERNAL: logger.external, # type: ignore
+  LOG_LEVEL_CRITICAL: logger.critical
+}
+
+log_level_from_env: str = os.environ.get("DEEPSTATE_LOG", 2)
+try:
+  logger.setLevel(LOG_LEVEL_INT_TO_STR[int(log_level_from_env)])
+except ValueError:
+  print(f"$DEEPSTATE_LOG contains invalid value `{log_level_from_env}`, "
+        "should be int in 0-6 (debug, trace, info, warning, error, external, critical).")
+  exit(1)
+except KeyError:
+  print(f"$DEEPSTATE_LOG is in invalid range, should be in 0-6 "
+        "(debug, trace, info, warning, error, external, critical).")
+  exit(1)
+
+__all__ = ["DeepStateLogger", "LOG_LEVEL_INT_TO_STR", "LOG_LEVEL_INT_TO_LOGGER", "LOG_LEVEL_DEBUG",
+            "LOG_LEVEL_TRACE", "LOG_LEVEL_INFO", "LOG_LEVEL_WARNING",
+            "LOG_LEVEL_ERROR", "LOG_LEVEL_EXTERNAL", "LOG_LEVEL_CRITICAL"]

--- a/bin/deepstate/core/__init__.py
+++ b/bin/deepstate/core/__init__.py
@@ -1,2 +1,3 @@
 from .symex import SymexFrontend, TestInfo
 from .fuzz import FuzzerFrontend, FuzzFrontendError
+__all__ = ["SymexFrontend", "TestInfo", "FuzzerFrontend", "FuzzFrontendError"]

--- a/bin/deepstate/core/base.py
+++ b/bin/deepstate/core/base.py
@@ -27,6 +27,13 @@ L = logging.getLogger("deepstate.core.base")
 L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
 
 
+class AnalysisBackendError(Exception):
+  """
+  Defines our custom exception class for AnalysisBackend
+  """
+  pass
+
+
 class AnalysisBackend(object):
   """
   Defines the root base object to inherit attributes and methods for any frontends that
@@ -48,8 +55,21 @@ class AnalysisBackend(object):
 
 
   def __init__(self):
+    """
+    Create and store variables:
+      - name (name for pretty printing)
+
+    User must define NAME members in inherited class.
+    """
+
+    # in case name supplied as `bin/fuzzer`, strip executable name
+    self.name: Optional[str] = self.NAME
+    if self.name is None:
+      raise AnalysisBackendError("AnalysisBackend.NAME not set")
+    L.debug(f"Analysis backend name: {self.name}")
+
     # parsed argument attributes
-    self.binary: Optional[str] = None
+    self.binary: str = None
     self.output_test_dir: str = "{}_out".format(str(self))
     self.timeout: int = 0
     self.num_workers: int = 1

--- a/bin/deepstate/core/base.py
+++ b/bin/deepstate/core/base.py
@@ -43,8 +43,11 @@ class AnalysisBackend(object):
   # name of tool executable, should be implemented by subclass
   NAME: ClassVar[str] = ''
 
-  # name of compiler executable, should be implemented by subclass
+  # dict of executable files, should be implemented by subclass
   EXECUTABLES: ClassVar[Dict[str,str]] = {}
+
+  # compiler executable
+  compiler_exe: ClassVar[Optional[str]] = None
 
   # temporary attribute for argparsing, and should be used to build up object attributes
   _ARGS: ClassVar[Optional[argparse.Namespace]] = None
@@ -57,6 +60,7 @@ class AnalysisBackend(object):
     """
     Create and store variables:
       - name (name for pretty printing)
+      - compiler_exe (compiler executable, optional)
 
     User must define NAME members in inherited class.
     """
@@ -66,6 +70,8 @@ class AnalysisBackend(object):
     if self.name == '':
       raise AnalysisBackendError("AnalysisBackend.NAME not set")
     L.debug(f"Analysis backend name: {self.name}")
+
+    AnalysisBackend.compiler_exe = self.EXECUTABLES.pop("COMPILER", None)
 
     # parsed argument attributes
     self.binary: str = None
@@ -102,10 +108,10 @@ class AnalysisBackend(object):
     else:
       parser = argparse.ArgumentParser(description="Use {} as a backend for DeepState".format(cls.NAME))
 
-    # Compilation/instrumentation support, only if COMPILER is set
+    # Compilation/instrumentation support, only if COMPILER is set in EXECUTABLES
     # TODO: extends compilation interface for symex engines that "compile" source to
     # binary, IR format, or boolean expressions for symbolic VM to reason with
-    if cls.EXECUTABLES.get("COMPILER", None):
+    if cls.compiler_exe:
       L.debug("Adding compilation support since a compiler was specified")
 
       # type: ignore

--- a/bin/deepstate/core/base.py
+++ b/bin/deepstate/core/base.py
@@ -20,7 +20,7 @@ import os
 import argparse
 import configparser
 
-from typing import Dict, ClassVar, Optional, Union, List, Any
+from typing import Dict, ClassVar, Optional, Union, List, Any, Tuple
 
 
 L = logging.getLogger("deepstate.core.base")
@@ -127,7 +127,8 @@ class AnalysisBackend(object):
     args = parser.parse_args()
 
     # from parsed arguments, modify dict copy if configuration is specified
-    _args: Dict[str, str] = vars(args)
+    _args: Dict[str, Any] = vars(args)
+    print(_args)
 
     # parse target_args
     target_args_parsed: List[Tuple[str, Optional[str]]] = []
@@ -153,10 +154,8 @@ class AnalysisBackend(object):
     return cls._ARGS
 
 
-  ConfigType = Dict[str, Dict[str, Any]]
-
   @staticmethod
-  def build_from_config(config: str, allowed_keys: Optional[List[str]] = None, include_sections: bool = False) -> Union[ConfigType, Dict[str, Any]]:
+  def build_from_config(config: str, allowed_keys: Optional[List[str]] = None, include_sections: bool = False) -> Union[Dict[str, Dict[str, Any]], Dict[str, Any]]:
     """
     Simple auxiliary helper that does safe and correct parsing of DeepState configurations. This can be used
     in the following manners:
@@ -167,10 +166,10 @@ class AnalysisBackend(object):
 
     :param config: path to configuration file
     :param allowed_keys: contains allowed keys that should be parsed
-    :param include_sections: if true, parse all sections, and return a ConfigType where keys are section names
+    :param include_sections: if true, parse all sections, and return a Dict[str, Dict[str, Any]] where keys are section names
     """
 
-    context: ConfigType = dict() # type: ignore
+    context: Dict[str, Dict[str, Any]] = dict() # type: ignore
 
     # reserved sections are ignored by executors, but can be used by other auxiliary tools
     # to reason about with.

--- a/bin/deepstate/core/base.py
+++ b/bin/deepstate/core/base.py
@@ -67,15 +67,15 @@ class AnalysisBackend(object):
 
     # in case name supplied as `bin/fuzzer`, strip executable name
     self.name: str = self.NAME
-    if self.name == '':
+    if not self.name:
       raise AnalysisBackendError("AnalysisBackend.NAME not set")
-    L.debug(f"Analysis backend name: {self.name}")
+    L.debug("Analysis backend name: %s", self.name)
 
     AnalysisBackend.compiler_exe = self.EXECUTABLES.pop("COMPILER", None)
 
     # parsed argument attributes
     self.binary: str = None
-    self.output_test_dir: str = "{}_out".format(str(self))
+    self.output_test_dir: str = f"{self}_out"
     self.timeout: int = 0
     self.num_workers: int = 1
     self.mem_limit: int = 50

--- a/bin/deepstate/core/base.py
+++ b/bin/deepstate/core/base.py
@@ -112,7 +112,7 @@ class AnalysisBackend(object):
       help="Number of worker jobs to spawn for analysis (default is 1).")
 
     parser.add_argument("--mem_limit", type=int, default=50,
-      help="Child process memory limit in MB (default is 50).")
+      help="Child process memory limit in MiB (default is 50). 0 for unlimited.")
 
     # DeepState-related options
     exec_group = parser.add_argument_group("DeepState Test Configuration")
@@ -128,7 +128,6 @@ class AnalysisBackend(object):
 
     # from parsed arguments, modify dict copy if configuration is specified
     _args: Dict[str, Any] = vars(args)
-    print(_args)
 
     # parse target_args
     target_args_parsed: List[Tuple[str, Optional[str]]] = []

--- a/bin/deepstate/core/base.py
+++ b/bin/deepstate/core/base.py
@@ -111,6 +111,8 @@ class AnalysisBackend(object):
       "-w", "--num_workers", default=1, type=int,
       help="Number of worker jobs to spawn for analysis (default is 1).")
 
+    parser.add_argument("--mem_limit", type=int, default=50,
+      help="Child process memory limit in MB (default is 50).")
 
     # DeepState-related options
     exec_group = parser.add_argument_group("DeepState Test Configuration")
@@ -119,13 +121,24 @@ class AnalysisBackend(object):
       help="DeepState unit test to run (equivalent to `--input_which_test`).")
 
     exec_group.add_argument(
-      "--prog_args", default=[], nargs=argparse.REMAINDER,
-      help="Other DeepState flags to pass to harness before execution, in format `--arg=val`.")
+      "--target_args", default=[], nargs='*',
+      help="Other DeepState flags to pass to harness before execution. Format: `a arg=val` -> `-a --arg1 val`.")
 
     args = parser.parse_args()
 
     # from parsed arguments, modify dict copy if configuration is specified
     _args: Dict[str, str] = vars(args)
+
+    # parse target_args
+    target_args_parsed: List[Tuple[str, Optional[str]]] = []
+    for arg in _args['target_args']:
+      vals = arg.split("=", 1)
+      key = vals[0]
+      val = None
+      if len(vals) == 2:
+        val = vals[1]
+      target_args_parsed.append((key, val))
+    _args['target_args'] = target_args_parsed
 
     # if configuration is specified, parse and replace argument instantiations
     if args.config:

--- a/bin/deepstate/core/base.py
+++ b/bin/deepstate/core/base.py
@@ -48,7 +48,20 @@ class AnalysisBackend(object):
 
 
   def __init__(self):
-    pass
+    # parsed argument attributes
+    self.binary: Optional[str] = None
+    self.output_test_dir: str = "{}_out".format(str(self))
+    self.timeout: int = 0
+    self.num_workers: int = 1
+    self.mem_limit: int = 50
+
+    self.compile_test: Optional[str] = None
+    self.compiler_args: Optional[str] = None
+    self.out_test_name: str = "out"
+
+    self.no_exit_compile: bool = False
+    self.which_test: Optional[str] = None
+    self.target_args: List[Any] = []
 
 
   @classmethod

--- a/bin/deepstate/core/fuzz.py
+++ b/bin/deepstate/core/fuzz.py
@@ -401,6 +401,19 @@ class FuzzerFrontend(AnalysisBackend):
     return cmd_dict
 
 
+  def main(self):
+    """
+    Helper method for calling fuzzer methods in correct order
+    """
+    try:
+      self.parse_args()
+      self.run()
+      return 0
+    except FuzzFrontendError as e:
+      L.error(e)
+      return 1
+
+
   ##############################################
   # Fuzzer process execution methods
   ##############################################

--- a/bin/deepstate/core/fuzz.py
+++ b/bin/deepstate/core/fuzz.py
@@ -54,15 +54,18 @@ class FuzzerFrontend(AnalysisBackend):
     Inherits:
       - name (name for pretty printing)
 
-    User must define NAME, FUZZER and COMPILER (if compiling) members in inherited fuzzer class.
+    User must define in inherited fuzzer class:
+      - NAME str
+      - EXECUTABLES dict with keys:
+          FUZZER, COMPILER (if compiling) and any executable it will use
 
     :param envvar: name of envvar to discover executables.
     """
     super(FuzzerFrontend, self).__init__()
 
-    self.fuzzer_exe: str = self.EXECUTABLES.pop("FUZZER", None)
-    if self.fuzzer_exe is None:
+    if "FUZZER" not in self.EXECUTABLES:
       raise FuzzFrontendError("FuzzerFrontend.EXECUTABLES[\"FUZZER\"] not set.")
+    self.fuzzer_exe: str = self.EXECUTABLES.pop("FUZZER")
 
     self.compiler_exe: Optional[str] = self.EXECUTABLES.pop("COMPILER", None)
 

--- a/bin/deepstate/core/fuzz.py
+++ b/bin/deepstate/core/fuzz.py
@@ -124,22 +124,18 @@ class FuzzerFrontend(AnalysisBackend):
     self._on: bool = False
 
     # parsed argument attributes
-    self.binary: Optional[str] = None
-    self.target_args: List[str] = []
-    self.output_test_dir: str = "{}_out".format(str(self))
-    self.timeout: int = 0
-    self.num_workers: int = 1
-
-    self.compile_test: Optional[str] = None
-    self.compiler_args: Optional[str] = None
-    self.out_test_name: str = "out"
+    self.input_seeds: Optional[str] = None
+    self.max_input_size: int = 8192
+    self.dictionary: Optional[str] = None
+    self.exec_timeout: Optional[int] = None
+    self.blackbox: Optional[bool] = None
+    self.fuzzer_args: List[Any] = []
 
     self.enable_sync: bool = False
     self.sync_cycle: int = 5
     self.sync_out: bool = True
     self.sync_dir: str = "out_sync"
 
-    self.which_test: Optional[str] = None
     self.post_stats: bool = False
 
 

--- a/bin/deepstate/core/fuzz.py
+++ b/bin/deepstate/core/fuzz.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import logging
-logging.basicConfig()
 
 import os
 import time
@@ -29,8 +28,7 @@ from typing import Optional, Dict, List, Any, Tuple
 from deepstate.core.base import AnalysisBackend, AnalysisBackendError
 
 
-L = logging.getLogger("deepstate.core.fuzz")
-L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
+L = logging.getLogger(__name__)
 
 
 class FuzzFrontendError(AnalysisBackendError):
@@ -430,7 +428,8 @@ class FuzzerFrontend(AnalysisBackend):
       "--", self.binary,
       "--input_test_file", input_symbol,
       "--abort_on_fail",
-      "--no_fork"
+      "--no_fork",
+      "--min_log_level", str(self.min_log_level)
     ])
 
     # append any other DeepState flags
@@ -457,7 +456,7 @@ class FuzzerFrontend(AnalysisBackend):
       self.parse_args()
       self.run()
       return 0
-    except FuzzFrontendError as e:
+    except AnalysisBackendError as e:
       L.error(e)
       return 1
 

--- a/bin/deepstate/core/fuzz.py
+++ b/bin/deepstate/core/fuzz.py
@@ -21,10 +21,9 @@ import time
 import sys
 import subprocess
 import argparse
-import functools
 import multiprocessing
 
-from typing import ClassVar, Optional, Dict, List, Any, Tuple
+from typing import Optional, Dict, List, Any, Tuple
 
 from deepstate.core.base import AnalysisBackend
 
@@ -252,7 +251,7 @@ class FuzzerFrontend(AnalysisBackend):
 
 
     # parse fuzzer_args
-    _args: Dict[str, str] = vars(cls._ARGS)
+    _args: Dict[str, Any] = vars(cls._ARGS)
 
     fuzzer_args_parsed: List[Tuple[str, Optional[str]]] = []
     for arg in _args['fuzzer_args']:
@@ -396,7 +395,7 @@ class FuzzerFrontend(AnalysisBackend):
     raise NotImplementedError("Must implement in frontend subclass.")
 
 
-  def build_cmd(self, cmd_list: List[str], input_symbol: str = "@@") -> List[str]:
+  def build_cmd(self, cmd_list: List[Optional[str]], input_symbol: str = "@@") -> List[Optional[str]]:
     """
     Helper method to be invoked by child fuzzer class's cmd() property method in order
     to finalize command called by the fuzzer executable with appropriate arguments for the
@@ -569,7 +568,7 @@ class FuzzerFrontend(AnalysisBackend):
     except FuzzFrontendError as e:
       raise e
 
-    except Exception as e:
+    except Exception:
       import traceback
       L.error(traceback.format_exc())
 

--- a/bin/deepstate/core/fuzz.py
+++ b/bin/deepstate/core/fuzz.py
@@ -155,15 +155,15 @@ class FuzzerFrontend(AnalysisBackend):
     method to extend and add own arguments or override for outstanding deviations in fuzzer CLIs.
 
     Arguments provided by this method and usable in fuzzers' functions.
-    Guaranteed arguments:
+    Guaranteed arguments (have default value):
       - output_test_dir (default: out)
-      - mem_limit (default: 50MB)
-      - max_input_size (default: 8192)
+      - mem_limit (default: 50MiB)
+      - max_input_size (default: 8192B)
       - fuzzer_args (default: {})
       - blackbox (default: False)
       - post_stats (default: False)
 
-    Optional arguments:
+    Optional arguments (may be None):
       - input_seeds
       - dictionary
       - exec_timeout
@@ -195,7 +195,7 @@ class FuzzerFrontend(AnalysisBackend):
 
     parser.add_argument(
       "-s", "--max_input_size", type=int, default=8192,
-      help="Maximum input size for input generator (default is 8192).")
+      help="Maximum input size for input generator in bytes (default is 8192). 0 for unlimited.")
 
     parser.add_argument("--dictionary", type=str,
       help="Optional fuzzer dictionary.")

--- a/bin/deepstate/core/fuzz.py
+++ b/bin/deepstate/core/fuzz.py
@@ -47,12 +47,12 @@ class FuzzerFrontend(AnalysisBackend):
     """
     Create and store variables:
       - fuzzer_exe (fuzzer executable file)
-      - compiler_exe (fuzzer compiler file, optional)
       - env (environment variable name)
       - search_dirs (directories inside fuzzer home dir where to look for executables)
 
     Inherits:
       - name (name for pretty printing)
+      - compiler_exe (fuzzer compiler file, optional)
 
     User must define in inherited fuzzer class:
       - NAME str
@@ -66,8 +66,6 @@ class FuzzerFrontend(AnalysisBackend):
     if "FUZZER" not in self.EXECUTABLES:
       raise FuzzFrontendError("FuzzerFrontend.EXECUTABLES[\"FUZZER\"] not set.")
     self.fuzzer_exe: str = self.EXECUTABLES.pop("FUZZER")
-
-    self.compiler_exe: Optional[str] = self.EXECUTABLES.pop("COMPILER", None)
 
     self.envvar: str = envvar
     self.env: Optional[str] = os.environ.get(envvar, None)
@@ -322,7 +320,7 @@ class FuzzerFrontend(AnalysisBackend):
     L.debug(f"Static library path: {lib_path}")
 
     # initialize compiler envvars
-    env["CC"] = self.compiler_exe
+    env["CC"] = self.compiler_exe.replace('++', '')
     env["CXX"] = self.compiler_exe
     L.debug(f"CC={env['CC']} and CXX={env['CXX']}")
 

--- a/bin/deepstate/core/symex.py
+++ b/bin/deepstate/core/symex.py
@@ -19,7 +19,8 @@ import struct
 import argparse
 import hashlib
 
-from deepstate import *
+from deepstate import (DeepStateLogger, LOG_LEVEL_INT_TO_STR, LOG_LEVEL_INT_TO_LOGGER,
+                        LOG_LEVEL_TRACE, LOG_LEVEL_ERROR, LOG_LEVEL_CRITICAL)
 from deepstate.core.base import AnalysisBackend
 
 
@@ -232,7 +233,7 @@ class SymexFrontend(AnalysisBackend):
     if os.environ.get("DEEPSTATE_LOG", None) is None:
       LOGGER.setLevel(LOG_LEVEL_INT_TO_STR[args.min_log_level])
     else:
-      L.info("Using log level from $DEEPSTATE_LOG.")
+      LOGGER.info("Using log level from $DEEPSTATE_LOG.")
 
     if args.output_test_dir is not None:
       test_dir = os.path.join(args.output_test_dir,

--- a/bin/deepstate/core/symex.py
+++ b/bin/deepstate/core/symex.py
@@ -19,7 +19,7 @@ import struct
 import argparse
 import hashlib
 
-from deepstate import (DeepStateLogger, LOG_LEVEL_INT_TO_STR, LOG_LEVEL_INT_TO_LOGGER,
+from deepstate import (DeepStateLogger, LOG_LEVEL_INT_TO_LOGGER,
                         LOG_LEVEL_TRACE, LOG_LEVEL_ERROR, LOG_LEVEL_CRITICAL)
 from deepstate.core.base import AnalysisBackend
 

--- a/bin/deepstate/core/symex.py
+++ b/bin/deepstate/core/symex.py
@@ -13,39 +13,18 @@
 # limitations under the License.
 
 import logging
-logging.basicConfig()
 
 import os
 import struct
 import argparse
 import hashlib
-import functools
 
+from deepstate import *
 from deepstate.core.base import AnalysisBackend
 
 
-LOGGER = logging.getLogger("deepstate")
-LOGGER.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
-
-LOG_LEVEL_DEBUG = 0
-LOG_LEVEL_TRACE = 1
-LOG_LEVEL_INFO = 2
-LOG_LEVEL_WARNING = 3
-LOG_LEVEL_ERROR = 4
-LOG_LEVEL_EXTERNAL = 5
-LOG_LEVEL_FATAL = 6
-
-LOGGER.trace = functools.partial(LOGGER.log, 15) # type: ignore
-logging.TRACE = 15 # type: ignore
-
-LOG_LEVEL_TO_LOGGER = {
-  LOG_LEVEL_DEBUG: LOGGER.debug,
-  LOG_LEVEL_TRACE: LOGGER.trace, # type: ignore
-  LOG_LEVEL_INFO: LOGGER.info,
-  LOG_LEVEL_WARNING: LOGGER.warning,
-  LOG_LEVEL_ERROR: LOGGER.error,
-  LOG_LEVEL_FATAL: LOGGER.critical
-}
+logging.setLoggerClass(DeepStateLogger)  # fails without it, don't know why
+LOGGER = logging.getLogger(__name__)
 
 
 class TestInfo(object):
@@ -132,10 +111,6 @@ class SymexFrontend(AnalysisBackend):
     parser.add_argument(
         "--verbosity", default=1, type=int,
         help="Verbosity level for symbolic execution tool (default: 1, lower means less output).")
-
-    parser.add_argument(
-        "--min_log_level", default=2, type=int,
-        help="Minimum DeepState log level to print (default: 2), 0-6 (debug, trace, info, warning, error, external, critical).")
 
     cls.parser = parser
     return super(SymexFrontend, cls).parse_args()
@@ -233,7 +208,7 @@ class SymexFrontend(AnalysisBackend):
     self.context['crashed'] = False
     self.context['abandoned'] = False
     self.context['log'] = []
-    for level in LOG_LEVEL_TO_LOGGER:
+    for level in LOG_LEVEL_INT_TO_LOGGER:
       self.context['stream_{}'.format(level)] = []
 
     self.context['info'] = info
@@ -254,15 +229,10 @@ class SymexFrontend(AnalysisBackend):
     # Create the output directory for this test case.
     args = self.parse_args()
 
-    logging_levels = {
-      LOG_LEVEL_DEBUG: logging.DEBUG,
-      LOG_LEVEL_TRACE: logging.TRACE,
-      LOG_LEVEL_INFO: logging.INFO,
-      LOG_LEVEL_WARNING: logging.WARNING,
-      LOG_LEVEL_ERROR: logging.ERROR,
-      LOG_LEVEL_FATAL: logging.CRITICAL
-    }
-    LOGGER.setLevel(logging_levels[args.min_log_level])
+    if os.environ.get("DEEPSTATE_LOG", None) is None:
+      LOGGER.setLevel(LOG_LEVEL_INT_TO_STR[args.min_log_level])
+    else:
+      L.info("Using log level from $DEEPSTATE_LOG.")
 
     if args.output_test_dir is not None:
       test_dir = os.path.join(args.output_test_dir,
@@ -282,7 +252,7 @@ class SymexFrontend(AnalysisBackend):
   def log_message(self, level, message):
     """Add `message` to the `level`-specific log as a `Stream` object for
     deferred logging (at the end of the state)."""
-    assert level in LOG_LEVEL_TO_LOGGER
+    assert level in LOG_LEVEL_INT_TO_LOGGER
     log = list(self.context['log'])  # Make a shallow copy (needed for Angr).
 
     if isinstance(message, (str, list, tuple)):
@@ -395,7 +365,7 @@ class SymexFrontend(AnalysisBackend):
 
     # Print out each log entry.
     for level, stream in self.context['log']:
-      logger = LOG_LEVEL_TO_LOGGER[level]
+      logger = LOG_LEVEL_INT_TO_LOGGER[level]
       logger(self._stream_to_message(stream))
 
     # Print out the first few input bytes to be helpful.
@@ -468,7 +438,7 @@ class SymexFrontend(AnalysisBackend):
       file, _ = self.read_c_string(file_ea, concretize=False)
       line = self.concretize(line, constrain=True)
       self.log_message(
-        LOG_LEVEL_FATAL, "Failed to add assumption {} in {}:{}".format(
+        LOG_LEVEL_CRITICAL, "Failed to add assumption {} in {}:{}".format(
             expr, file, line))
       self.abandon_test()
 
@@ -480,7 +450,7 @@ class SymexFrontend(AnalysisBackend):
     end_ea = self.concretize(end_ea, constrain=True)
     if end_ea < begin_ea:
       self.log_message(
-          LOG_LEVEL_FATAL,
+          LOG_LEVEL_CRITICAL,
           "Invalid range [{:x}, {:x}) to McTest_Concretize".format(
               begin_ea, end_ea))
       self.abandon_test()
@@ -539,8 +509,8 @@ class SymexFrontend(AnalysisBackend):
     as having aborted due to some unrecoverable error."""
     info = self.context['info']
     ea = self.concretize(arg, constrain=True)
-    self.log_message(LOG_LEVEL_FATAL, self.read_c_string(ea)[0])
-    self.log_message(LOG_LEVEL_FATAL, "Abandoned: {}".format(info.name))
+    self.log_message(LOG_LEVEL_CRITICAL, self.read_c_string(ea)[0])
+    self.log_message(LOG_LEVEL_CRITICAL, "Abandoned: {}".format(info.name))
     self.abandon_test()
 
   def api_log(self, level, ea):
@@ -550,10 +520,10 @@ class SymexFrontend(AnalysisBackend):
 
     level = self.concretize(level, constrain=True)
     ea = self.concretize(ea, constrain=True)
-    assert level in LOG_LEVEL_TO_LOGGER
+    assert level in LOG_LEVEL_INT_TO_LOGGER
     self.log_message(level, self.read_c_string(ea, concretize=False)[0])
 
-    if level == LOG_LEVEL_FATAL:
+    if level == LOG_LEVEL_CRITICAL:
       self.api_fail()
     elif level == LOG_LEVEL_ERROR:
       self.api_soft_fail()
@@ -563,7 +533,7 @@ class SymexFrontend(AnalysisBackend):
     """Read the format information and int or float value data from memory
     and record it into a stream."""
     level = self.concretize(level, constrain=True)
-    assert level in LOG_LEVEL_TO_LOGGER
+    assert level in LOG_LEVEL_INT_TO_LOGGER
 
     format_ea = self.concretize(format_ea, constrain=True)
     unpack_ea = self.concretize(unpack_ea, constrain=True)
@@ -597,7 +567,7 @@ class SymexFrontend(AnalysisBackend):
     """Implements the `_DeepState_StreamString`, which streams a C-string into a
     holding buffer for the log."""
     level = self.concretize(level, constrain=True)
-    assert level in LOG_LEVEL_TO_LOGGER
+    assert level in LOG_LEVEL_INT_TO_LOGGER
 
     format_ea = self.concretize(format_ea, constrain=True)
     str_ea = self.concretize(str_ea, constrain=True)
@@ -613,7 +583,7 @@ class SymexFrontend(AnalysisBackend):
     """Implements DeepState_ClearStream, which clears the contents of a stream
     for level `level`."""
     level = self.concretize(level, constrain=True)
-    assert level in LOG_LEVEL_TO_LOGGER
+    assert level in LOG_LEVEL_INT_TO_LOGGER
     stream_id = 'stream_{}'.format(level)
     self.context[stream_id] = []
 
@@ -621,14 +591,14 @@ class SymexFrontend(AnalysisBackend):
     """Implements DeepState_LogStream, which converts the contents of a stream
     for level `level` into a log for level `level`."""
     level = self.concretize(level, constrain=True)
-    assert level in LOG_LEVEL_TO_LOGGER
+    assert level in LOG_LEVEL_INT_TO_LOGGER
     stream_id = 'stream_{}'.format(level)
     stream = self.context[stream_id]
     if len(stream):
       self.context[stream_id] = []
       self.log_message(level, Stream(stream))
 
-      if level == LOG_LEVEL_FATAL:
+      if level == LOG_LEVEL_CRITICAL:
         self.api_fail()
       elif level == LOG_LEVEL_ERROR:
         self.api_soft_fail()

--- a/bin/deepstate/core/symex.py
+++ b/bin/deepstate/core/symex.py
@@ -230,11 +230,6 @@ class SymexFrontend(AnalysisBackend):
     # Create the output directory for this test case.
     args = self.parse_args()
 
-    if os.environ.get("DEEPSTATE_LOG", None) is None:
-      LOGGER.setLevel(LOG_LEVEL_INT_TO_STR[args.min_log_level])
-    else:
-      LOGGER.info("Using log level from $DEEPSTATE_LOG.")
-
     if args.output_test_dir is not None:
       test_dir = os.path.join(args.output_test_dir,
                               os.path.basename(info.file_name),
@@ -245,8 +240,7 @@ class SymexFrontend(AnalysisBackend):
         pass
 
       if not os.path.isdir(test_dir):
-        LOGGER.critical("Cannot create test output directory: {}".format(
-            test_dir))
+        LOGGER.critical("Cannot create test output directory: %s", test_dir)
 
       self.context['test_dir'] = test_dir
 
@@ -336,12 +330,12 @@ class SymexFrontend(AnalysisBackend):
       with open(test_file, "wb") as f:
         f.write(input_bytes)
     except:
-      LOGGER.critical("Error saving input to {}".format(test_file))
+      LOGGER.critical("Error saving input to %s", test_file)
 
     if not passing:
-      LOGGER.info("Saved test case in file {}".format(test_file))
+      LOGGER.info("Saved test case in file %s", test_file)
     else:
-      LOGGER.trace("Saved test case in file {}".format(test_file))
+      LOGGER.trace("Saved test case in file %s", test_file)
 
   def report(self):
     """Report on the pass/fail status of a test case, and dump its log."""
@@ -372,9 +366,9 @@ class SymexFrontend(AnalysisBackend):
     # Print out the first few input bytes to be helpful.
     lots_of_bytes = len(input_bytes) > 20 and " ..." or ""
     bytes_to_show = min(20, len(input_bytes))
-    LOGGER.trace("Input: {}{}".format(
+    LOGGER.trace("Input: %s%s", 
         " ".join("{:02x}".format(b) for b in input_bytes[:bytes_to_show]),
-        lots_of_bytes))
+        lots_of_bytes)
 
     self._save_test(info, input_bytes)
 

--- a/bin/deepstate/executors/auxiliary/ensembler.py
+++ b/bin/deepstate/executors/auxiliary/ensembler.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import logging
-logging.basicConfig()
 
 import os
 import sys
@@ -34,8 +33,7 @@ from deepstate.executors.fuzz.angora import Angora
 from deepstate.executors.fuzz.eclipser import Eclipser
 
 
-L = logging.getLogger("deepstate.ensembler")
-L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
+L = logging.getLogger(__name__)
 
 
 class Ensembler(FuzzerFrontend):

--- a/bin/deepstate/executors/auxiliary/ensembler.py
+++ b/bin/deepstate/executors/auxiliary/ensembler.py
@@ -178,7 +178,7 @@ class Ensembler(FuzzerFrontend):
 
     # initialize target - test str if user specified a harness, or a list to already-compiled binaries
     target = self.test if not self.test_dir else list([f for f in os.listdir(self.test_dir)])
-    L.info("Provisioning environment with target `%s`", fuzz_map)
+    L.info("Provisioning environment with target `%s`", target)
 
     self.fuzzers = list(self._init_fuzzers())
     L.debug("Fuzzers for ensembling: %s", self.fuzzers)

--- a/bin/deepstate/executors/auxiliary/ensembler.py
+++ b/bin/deepstate/executors/auxiliary/ensembler.py
@@ -44,7 +44,7 @@ class Ensembler(FuzzerFrontend):
   seed synchronization between them.
   """
 
-  FUZZER = "deepstate-ensembler"
+  EXECUTABLES = {"FUZZER": "deepstate-ensembler"}
 
   @classmethod
   def parse_args(cls):

--- a/bin/deepstate/executors/auxiliary/ensembler.py
+++ b/bin/deepstate/executors/auxiliary/ensembler.py
@@ -284,7 +284,7 @@ class Ensembler(FuzzerFrontend):
         "max_input_size": self.max_input_size if self.max_input_size else 8192,
         "mem_limit": 50,
         "which_test": self.which_test,
-        "prog_args": self.prog_args,
+        "target_args": self.target_args,
 
         # set sync options for all fuzzers (TODO): configurable exec cycle
         # set sync_out to output global fuzzer stats, set as default

--- a/bin/deepstate/executors/auxiliary/ensembler.py
+++ b/bin/deepstate/executors/auxiliary/ensembler.py
@@ -104,11 +104,11 @@ class Ensembler(FuzzerFrontend):
     # initial path check
     _test = self.test if not self.test_dir else self.test_dir
     if not os.path.exists(_test):
-      L.error(f"Target path `{_test}` does not exist. Exiting.")
+      L.error("Target path `%s` does not exist. Exiting.", _test)
       sys.exit(1)
 
     if not os.path.isdir(self.input_seeds):
-      L.error(f"Input seeds directory `{self.input_seeds}` does not exist. Exiting.")
+      L.error("Input seeds directory `%s` does not exist. Exiting.", self.input_seeds)
       sys.exit(1)
 
     if not os.path.isdir(self.output_test_dir):
@@ -163,7 +163,7 @@ class Ensembler(FuzzerFrontend):
         if str(fuzzer).lower() == _get_fuzzer(test):
           fuzz_map[fuzzer].append(test)
 
-    L.debug(f"Fuzzer and corresponding test cases: {fuzz_map}")
+    L.debug("Fuzzer and corresponding test cases: %s", fuzz_map)
     return fuzz_map
 
 
@@ -178,10 +178,10 @@ class Ensembler(FuzzerFrontend):
 
     # initialize target - test str if user specified a harness, or a list to already-compiled binaries
     target = self.test if not self.test_dir else list([f for f in os.listdir(self.test_dir)])
-    L.info(f"Provisioning environment with target `{target}`")
+    L.info("Provisioning environment with target `%s`", fuzz_map)
 
     self.fuzzers = list(self._init_fuzzers())
-    L.debug(f"Fuzzers for ensembling: {self.fuzzers}")
+    L.debug("Fuzzers for ensembling: %s", self.fuzzers)
 
     # given a path to a DeepState harness, provision/compile, and retrieve test bins
     if isinstance(target, str):
@@ -193,7 +193,7 @@ class Ensembler(FuzzerFrontend):
       L.info("Detected workspace target. Retrieving harnesses from workspace.")
       self.targets = self._get_tests(target)
 
-    L.debug(f"Target for analysis: {self.targets}")
+    L.debug("Target for analysis: %s", self.targets)
 
 
   def _provision_workspace(self, test_case):
@@ -210,7 +210,7 @@ class Ensembler(FuzzerFrontend):
     for fuzzer in self.fuzzers:
 
       test_name = self.workspace + "/" + test_case.split(".")[0]
-      L.debug(f"Compiling `{test_name}` for fuzzer `{fuzzer}`")
+      L.debug("Compiling `%s` for fuzzer `%s`", test_name, fuzzer)
 
       cmd_map = {
         "compile_test": test_case,
@@ -224,7 +224,7 @@ class Ensembler(FuzzerFrontend):
 
       fuzzer.init_from_dict(cmd_map)
 
-      L.info(f"Compiling test case {test_case} as `{test_name}` with {fuzzer}")
+      L.info("Compiling test case %s as `%s` with %s", test_case, test_name, fuzzer)
       fuzzer.compile()
 
     return [test for test in os.listdir(self.workspace)]
@@ -341,7 +341,7 @@ class Ensembler(FuzzerFrontend):
         args = (None, True)
 
 
-      L.info(f"Initialized {fuzzer} for ensemble-fuzzing and spinning up child proc.")
+      L.info("Initialized %s for ensemble-fuzzing and spinning up child proc.", fuzzer)
 
       # initialize concurrent process and add to process pool
       proc = Process(target=fuzzer.run, args=args)

--- a/bin/deepstate/executors/fuzz/afl.py
+++ b/bin/deepstate/executors/fuzz/afl.py
@@ -18,7 +18,7 @@ import logging
 import argparse
 import shutil
 
-from typing import ClassVar, List, Dict, Optional
+from typing import List, Dict, Optional
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
@@ -29,10 +29,10 @@ L = logging.getLogger(__name__)
 class AFL(FuzzerFrontend):
   """ Defines AFL fuzzer frontend """
 
-  NAME: ClassVar[str] = "AFL"
-  EXECUTABLES: ClassVar[Dict[str,str]] = {"FUZZER": "afl-fuzz",
-                                          "COMPILER": "afl-clang++"
-                                          }
+  NAME = "AFL"
+  EXECUTABLES = {"FUZZER": "afl-fuzz",
+                  "COMPILER": "afl-clang++"
+                  }
 
   @classmethod
   def parse_args(cls) -> None:

--- a/bin/deepstate/executors/fuzz/afl.py
+++ b/bin/deepstate/executors/fuzz/afl.py
@@ -229,16 +229,9 @@ class AFL(FuzzerFrontend):
         print(f"{fstat}:\t\t\t{val}")
 
 
-
 def main():
   fuzzer = AFL()
-
-  # parse user arguments and build object
-  fuzzer.parse_args()
-
-  # run fuzzer with parsed attributes
-  fuzzer.run()
-  return 0
+  return fuzzer.main()
 
 
 if __name__ == "__main__":

--- a/bin/deepstate/executors/fuzz/afl.py
+++ b/bin/deepstate/executors/fuzz/afl.py
@@ -91,6 +91,13 @@ class AFL(FuzzerFrontend):
       if not "core" in f.read():
         raise FuzzFrontendError("No core dump pattern set. Execute 'echo core | sudo tee /proc/sys/kernel/core_pattern'")
 
+    with open("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor") as f:
+      if not "perf" in f.read(4):
+        with open("/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq") as f_min:
+          with open("/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq") as f_max:
+            if f_min.read() != f_max.read():
+              raise FuzzFrontendError("Suboptimal CPU scaling governor. Execute 'echo performance | sudo tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor'")
+
     super().pre_exec()
 
     # require input seeds if we aren't in dumb mode, or we are using crash mode

--- a/bin/deepstate/executors/fuzz/afl.py
+++ b/bin/deepstate/executors/fuzz/afl.py
@@ -18,10 +18,9 @@ import logging
 import argparse
 import shutil
 
-from typing import ClassVar, List, Dict, Any, Optional, Tuple
+from typing import ClassVar, List, Dict, Optional
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
-from deepstate.core.base import AnalysisBackend
 
 
 L = logging.getLogger("deepstate.frontend.afl")

--- a/bin/deepstate/executors/fuzz/afl.py
+++ b/bin/deepstate/executors/fuzz/afl.py
@@ -23,8 +23,7 @@ from typing import ClassVar, List, Dict, Optional
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
 
-L = logging.getLogger("deepstate.frontend.afl")
-L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
+L = logging.getLogger(__name__)
 
 
 class AFL(FuzzerFrontend):

--- a/bin/deepstate/executors/fuzz/angora.py
+++ b/bin/deepstate/executors/fuzz/angora.py
@@ -19,7 +19,7 @@ import logging
 import argparse
 import subprocess
 
-from typing import ClassVar, List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
@@ -30,12 +30,12 @@ L = logging.getLogger(__name__)
 class Angora(FuzzerFrontend):
 
   # these classvars are set under the assumption that $ANGORA_PATH is set to the built source
-  NAME: ClassVar[str] = "Angora"
-  SEARCH_DIRS: ClassVar[List[str]] = ["bin", "clang+llvm", "tools"]
-  EXECUTABLES: ClassVar[Dict[str,str]] = {"FUZZER": "angora_fuzzer",
-                                          "COMPILER": "angora-clang++",
-                                          "GEN_LIB_ABILIST": "gen_library_abilist.sh"
-                                          }
+  NAME = "Angora"
+  SEARCH_DIRS = ["bin", "clang+llvm", "tools"]
+  EXECUTABLES = {"FUZZER": "angora_fuzzer",
+                  "COMPILER": "angora-clang++",
+                  "GEN_LIB_ABILIST": "gen_library_abilist.sh"
+                  }
 
 
   @classmethod

--- a/bin/deepstate/executors/fuzz/angora.py
+++ b/bin/deepstate/executors/fuzz/angora.py
@@ -24,8 +24,7 @@ from typing import ClassVar, List, Dict, Optional, Any
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
 
-L = logging.getLogger("deepstate.frontend.angora")
-L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
+L = logging.getLogger(__name__)
 
 
 class Angora(FuzzerFrontend):

--- a/bin/deepstate/executors/fuzz/angora.py
+++ b/bin/deepstate/executors/fuzz/angora.py
@@ -114,7 +114,7 @@ class Angora(FuzzerFrontend):
 
     # make a binary with taint tracking information
     taint_path: str = "/usr/local/lib/libdeepstate_taint.a"
-    L.debu("Static library path: %s", taint_path)
+    L.debug("Static library path: %s", taint_path)
 
     taint_flags: List[str] = ["-ldeepstate_taint"]
     if self.compiler_args:

--- a/bin/deepstate/executors/fuzz/angora.py
+++ b/bin/deepstate/executors/fuzz/angora.py
@@ -69,7 +69,7 @@ class Angora(FuzzerFrontend):
     if self.ignore_calls: # type: ignore
 
       libpath: List[str] = self.ignore_calls.split(":") # type: ignore
-      L.debug(f"Ignoring library objects: {libpath}")
+      L.debug("Ignoring library objects: %s", libpath)
 
       out_file: str = "abilist.txt"
 
@@ -81,7 +81,7 @@ class Angora(FuzzerFrontend):
 
         # instantiate command to call, but store output to buffer
         cmd: List[str] = [self.EXECUTABLES["GEN_LIB_ABILIST"], path, "discard"]
-        L.debug(f"Compilation command: {cmd}")
+        L.debug("Compilation command: %s", cmd)
 
         out: bytes = subprocess.check_output(cmd)
         ignore_bufs += [out]
@@ -98,12 +98,12 @@ class Angora(FuzzerFrontend):
 
     # make a binary with light instrumentation
     fast_path: str = "/usr/local/lib/libdeepstate_fast.a"
-    L.debug(f"Static library path: {fast_path}")
+    L.debug("Static library path: %s", fast_path)
 
     fast_flags: List[str] = ["-ldeepstate_fast"]
     if self.compiler_args:
       fast_flags += [arg for arg in self.compiler_args.split(" ")]
-    L.info(f"Compiling {self.compile_test} for {self.name} with light instrumentation")
+    L.info("Compiling %s for %s with light instrumentation.", self.compile_test, self.name)
     super().compile(fast_path, fast_flags, self.out_test_name + ".fast", env=env)
 
     # initialize envvar for instrumentation framework
@@ -114,12 +114,12 @@ class Angora(FuzzerFrontend):
 
     # make a binary with taint tracking information
     taint_path: str = "/usr/local/lib/libdeepstate_taint.a"
-    L.debug(f"Static library path: {taint_path}")
+    L.debu("Static library path: %s", taint_path)
 
     taint_flags: List[str] = ["-ldeepstate_taint"]
     if self.compiler_args:
       taint_flags += [arg for arg in self.compiler_args.split(' ')]
-    L.info(f"Compiling {self.compile_test} for {self.name} with taint tracking")
+    L.info("Compiling %s for %s with taint tracking", self.compile_test, self.name)
     super().compile(taint_path, taint_flags, self.out_test_name + ".taint", env=env)
 
 
@@ -143,11 +143,11 @@ class Angora(FuzzerFrontend):
     if len(os.listdir(self.input_seeds)) == 0:
       raise FuzzFrontendError(f"No seeds present in directory `{self.input_seeds}`.")
 
-    if self.blackbox == True:
+    if self.blackbox is True:
       raise FuzzFrontendError(f"Blackbox fuzzing is not supported by {self.name}.")
 
     if self.dictionary:
-      L.error(f"{self.name} can't use dictionaries.")
+      L.error("%s can't use dictionaries.", self.name)
 
     # require output directory
     if not self.output_test_dir:

--- a/bin/deepstate/executors/fuzz/angora.py
+++ b/bin/deepstate/executors/fuzz/angora.py
@@ -214,13 +214,7 @@ class Angora(FuzzerFrontend):
 
 def main():
   fuzzer = Angora(envvar="ANGORA")
-
-  # parse user arguments and build object
-  fuzzer.parse_args()
-
-  # run fuzzer with parsed attributes
-  fuzzer.run()
-  return 0
+  return fuzzer.main()
 
 
 if __name__ == "__main__":

--- a/bin/deepstate/executors/fuzz/eclipser.py
+++ b/bin/deepstate/executors/fuzz/eclipser.py
@@ -141,10 +141,14 @@ class Eclipser(FuzzerFrontend):
 
 
 def main():
-  fuzzer = Eclipser(envvar="ECLIPSER_HOME")
-  fuzzer.parse_args()
-  fuzzer.run(compiler="dotnet")
-  return 0
+  try:
+    fuzzer = Eclipser(envvar="ECLIPSER_HOME")
+    fuzzer.parse_args()
+    fuzzer.run(compiler="dotnet")
+    return 0
+  except FuzzFrontendError as e:
+    L.error(e)
+    return 1
 
 
 if __name__ == "__main__":

--- a/bin/deepstate/executors/fuzz/eclipser.py
+++ b/bin/deepstate/executors/fuzz/eclipser.py
@@ -19,7 +19,7 @@ import shutil
 import logging
 import subprocess
 
-from typing import ClassVar, List, Dict
+from typing import List, Dict
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
@@ -33,11 +33,11 @@ class Eclipser(FuzzerFrontend):
   in order to interface the executable DLL for greybox concolic testing.
   """
 
-  NAME: ClassVar[str] = "Eclipser"
-  SEARCH_DIRS: ClassVar[List[str]] = ["build"]
-  EXECUTABLES: ClassVar[Dict[str,str]] = {"FUZZER": "Eclipser.dll",
-                                          "COMPILER": "clang++"  # for regular compilation
-                                          }
+  NAME = "Eclipser"
+  SEARCH_DIRS = ["build"]
+  EXECUTABLES = {"FUZZER": "Eclipser.dll",
+                  "COMPILER": "clang++"  # for regular compilation
+                  }
 
 
   def print_help(self):

--- a/bin/deepstate/executors/fuzz/eclipser.py
+++ b/bin/deepstate/executors/fuzz/eclipser.py
@@ -24,8 +24,7 @@ from typing import ClassVar, List, Dict
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
 
-L = logging.getLogger("deepstate.frontend.eclipser")
-L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
+L = logging.getLogger(__name__)
 
 
 class Eclipser(FuzzerFrontend):

--- a/bin/deepstate/executors/fuzz/eclipser.py
+++ b/bin/deepstate/executors/fuzz/eclipser.py
@@ -34,12 +34,15 @@ class Eclipser(FuzzerFrontend):
   in order to interface the executable DLL for greybox concolic testing.
   """
 
-  NAME: ClassVar[str] = "Eclipser.dll"
-  COMPILER: ClassVar[str] = "clang++" 	 # for regular compilation
+  NAME: ClassVar[str] = "Eclipser"
+  SEARCH_DIRS: ClassVar[List[str]] = ["build"]
+  EXECUTABLES: ClassVar[Dict[str,str]] = {"FUZZER": "Eclipser.dll",
+                                          "COMPILER": "clang++"  # for regular compilation
+                                          }
 
 
   def print_help(self):
-    subprocess.call(["dotnet", self.fuzzer, "fuzz", "--help"])
+    subprocess.call(["dotnet", self.fuzzer_exe, "fuzz", "--help"])
 
 
   def compile(self) -> None: # type: ignore
@@ -150,8 +153,8 @@ class Eclipser(FuzzerFrontend):
     out: str = self.output_test_dir
 
     L.info("Performing post-processing decoding on testcases and crashes")
-    subprocess.call(["dotnet", self.fuzzer, "decode", "-i", out + "/testcase", "-o", out + "/decoded"])
-    subprocess.call(["dotnet", self.fuzzer, "decode", "-i", out + "/crash", "-o", out + "/decoded"])
+    subprocess.call(["dotnet", self.fuzzer_exe, "decode", "-i", out + "/testcase", "-o", out + "/decoded"])
+    subprocess.call(["dotnet", self.fuzzer_exe, "decode", "-i", out + "/crash", "-o", out + "/decoded"])
     for f in glob.glob(out + "/decoded/decoded_files/*"):
       shutil.copy(f, out)
     shutil.rmtree(out + "/decoded")

--- a/bin/deepstate/executors/fuzz/eclipser.py
+++ b/bin/deepstate/executors/fuzz/eclipser.py
@@ -19,7 +19,7 @@ import shutil
 import logging
 import subprocess
 
-from typing import ClassVar, List, Dict, Optional
+from typing import ClassVar, List, Dict
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 

--- a/bin/deepstate/executors/fuzz/honggfuzz.py
+++ b/bin/deepstate/executors/fuzz/honggfuzz.py
@@ -26,8 +26,11 @@ L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
 
 class Honggfuzz(FuzzerFrontend):
 
-  NAME: ClassVar[str] = "honggfuzz"
-  COMPILER: ClassVar[str] = "hfuzz-clang++"
+  NAME: ClassVar[str] = "HonggFuzz"
+  SEARCH_DIRS: ClassVar[List[str]] = ["hfuzz_cc"]
+  EXECUTABLES: ClassVar[Dict[str,str]] = {"FUZZER": "honggfuzz",
+                                          "COMPILER": "hfuzz-clang++"
+                                          }
 
 
   @classmethod
@@ -65,7 +68,7 @@ class Honggfuzz(FuzzerFrontend):
         raise FuzzFrontendError(f"Output test dir (`{self.output_test_dir}`) is not a directory.")
 
     if not self.input_seeds:
-      raise FuzzFrontendError("Must provide -i/--input_seeds option for Honggfuzz.")
+      raise FuzzFrontendError(f"Must provide -i/--input_seeds option for {self.name}.")
 
     if not os.path.exists(self.input_seeds):
       raise FuzzFrontendError(f"Input seeds dir (`{self.input_seeds}`) doesn't exist.")
@@ -184,7 +187,7 @@ class Honggfuzz(FuzzerFrontend):
 
 
 def main():
-  fuzzer = Honggfuzz()
+  fuzzer = Honggfuzz(envvar="HONGGFUZZ_HOME")
   return fuzzer.main()
 
 

--- a/bin/deepstate/executors/fuzz/honggfuzz.py
+++ b/bin/deepstate/executors/fuzz/honggfuzz.py
@@ -16,7 +16,7 @@ import os
 import logging
 import argparse
 
-from typing import ClassVar, List, Dict, Optional
+from typing import List, Dict, Optional
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
@@ -25,11 +25,11 @@ L = logging.getLogger(__name__)
 
 class Honggfuzz(FuzzerFrontend):
 
-  NAME: ClassVar[str] = "HonggFuzz"
-  SEARCH_DIRS: ClassVar[List[str]] = ["hfuzz_cc"]
-  EXECUTABLES: ClassVar[Dict[str,str]] = {"FUZZER": "honggfuzz",
-                                          "COMPILER": "hfuzz-clang++"
-                                          }
+  NAME = "HonggFuzz"
+  SEARCH_DIRS = ["hfuzz_cc"]
+  EXECUTABLES = {"FUZZER": "honggfuzz",
+                  "COMPILER": "hfuzz-clang++"
+                  }
 
 
   @classmethod

--- a/bin/deepstate/executors/fuzz/honggfuzz.py
+++ b/bin/deepstate/executors/fuzz/honggfuzz.py
@@ -20,8 +20,7 @@ from typing import ClassVar, List, Dict, Optional
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
-L = logging.getLogger("deepstate.frontend.honggfuzz")
-L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
+L = logging.getLogger(__name__)
 
 
 class Honggfuzz(FuzzerFrontend):

--- a/bin/deepstate/executors/fuzz/honggfuzz.py
+++ b/bin/deepstate/executors/fuzz/honggfuzz.py
@@ -194,9 +194,7 @@ class Honggfuzz(FuzzerFrontend):
 
 def main():
   fuzzer = Honggfuzz()
-  fuzzer.parse_args()
-  fuzzer.run()
-  return 0
+  return fuzzer.main()
 
 
 if __name__ == "__main__":

--- a/bin/deepstate/executors/fuzz/libfuzzer.py
+++ b/bin/deepstate/executors/fuzz/libfuzzer.py
@@ -73,7 +73,7 @@ class LibFuzzer(FuzzerFrontend):
     if not os.path.isdir(self.output_test_dir):
       raise FuzzFrontendError(f"Output test dir (`{self.output_test_dir}`) is not a directory.")
 
-    if self.blackbox == True:
+    if self.blackbox is True:
       raise FuzzFrontendError("Blackbox fuzzing is not supported by libFuzzer.")
 
     if self.input_seeds:

--- a/bin/deepstate/executors/fuzz/libfuzzer.py
+++ b/bin/deepstate/executors/fuzz/libfuzzer.py
@@ -115,9 +115,7 @@ class LibFuzzer(FuzzerFrontend):
 
 def main():
   fuzzer = LibFuzzer()
-  fuzzer.parse_args()
-  fuzzer.run()
-  return 0
+  return fuzzer.main()
 
 
 if __name__ == "__main__":

--- a/bin/deepstate/executors/fuzz/libfuzzer.py
+++ b/bin/deepstate/executors/fuzz/libfuzzer.py
@@ -17,7 +17,7 @@ import os
 import logging
 import argparse
 
-from typing import ClassVar, List, Dict
+from typing import List
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
@@ -25,10 +25,10 @@ L = logging.getLogger(__name__)
 
 class LibFuzzer(FuzzerFrontend):
 
-  NAME: ClassVar[str] = "libFuzzer"
-  EXECUTABLES: ClassVar[Dict[str,str]] = {"FUZZER": "placeholder_replace_with_binary",
-                                          "COMPILER": "clang++"
-                                          }
+  NAME = "libFuzzer"
+  EXECUTABLES = {"FUZZER": "placeholder_replace_with_binary",
+                  "COMPILER": "clang++"
+                  }
 
   @classmethod
   def parse_args(cls) -> None:

--- a/bin/deepstate/executors/fuzz/libfuzzer.py
+++ b/bin/deepstate/executors/fuzz/libfuzzer.py
@@ -17,7 +17,7 @@ import os
 import logging
 import argparse
 
-from typing import ClassVar, List, Dict, Optional
+from typing import ClassVar, List
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 

--- a/bin/deepstate/executors/fuzz/libfuzzer.py
+++ b/bin/deepstate/executors/fuzz/libfuzzer.py
@@ -21,9 +21,7 @@ from typing import ClassVar, List, Dict
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
-L = logging.getLogger("deepstate.frontend.libfuzzer")
-L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
-
+L = logging.getLogger(__name__)
 
 class LibFuzzer(FuzzerFrontend):
 

--- a/bin/deepstate/executors/fuzz/libfuzzer.py
+++ b/bin/deepstate/executors/fuzz/libfuzzer.py
@@ -17,7 +17,7 @@ import os
 import logging
 import argparse
 
-from typing import ClassVar, List
+from typing import ClassVar, List, Dict
 
 from deepstate.core import FuzzerFrontend, FuzzFrontendError
 
@@ -27,9 +27,10 @@ L.setLevel(os.environ.get("DEEPSTATE_LOG", "INFO").upper())
 
 class LibFuzzer(FuzzerFrontend):
 
-  NAME: ClassVar[str] = "clang++"    # placeholder, set as harness binary later
-  COMPILER: ClassVar[str] = "clang++"
-
+  NAME: ClassVar[str] = "libFuzzer"
+  EXECUTABLES: ClassVar[Dict[str,str]] = {"FUZZER": "placeholder_replace_with_binary",
+                                          "COMPILER": "clang++"
+                                          }
 
   @classmethod
   def parse_args(cls) -> None:
@@ -53,10 +54,11 @@ class LibFuzzer(FuzzerFrontend):
     """
     Perform argparse and environment-related sanity checks.
     """
-    super().pre_exec()
-
     # first, redefine and override fuzzer as harness executable
-    self.fuzzer = self.binary # type: ignore
+    self.binary = os.path.abspath(self.binary)
+    self.fuzzer_exe = self.binary # type: ignore
+
+    super().pre_exec()
 
     # require output directory
     if not self.output_test_dir:
@@ -119,7 +121,7 @@ class LibFuzzer(FuzzerFrontend):
 
 
 def main():
-  fuzzer = LibFuzzer()
+  fuzzer = LibFuzzer(envvar="LIBFUZZER_HOME")
   return fuzzer.main()
 
 

--- a/bin/deepstate/executors/symex/angr.py
+++ b/bin/deepstate/executors/symex/angr.py
@@ -20,8 +20,7 @@ import traceback
 
 from deepstate.core import SymexFrontend, TestInfo
 
-L = logging.getLogger("deepstate.angr")
-L.setLevel(logging.INFO)
+L = logging.getLogger(__name__)
 
 
 class DeepAngr(SymexFrontend):

--- a/bin/deepstate/executors/symex/angr.py
+++ b/bin/deepstate/executors/symex/angr.py
@@ -300,7 +300,7 @@ def do_run_test(project, test, apis, run_state, should_call_state):
   try:
     test_manager.run()
   except Exception as e:
-    L.error("Uncaught exception: {}\n{}".format(e, traceback.format_exc()))
+    L.error("Uncaught exception: %s\n%s", e, traceback.format_exc())
 
   for state in test_manager.deadended:
     DeepAngr(state=state).report()
@@ -315,7 +315,7 @@ def run_test(project, test, apis, run_state, should_call_state=True):
   try:
     do_run_test(project, test, apis, run_state, should_call_state)
   except Exception as e:
-    L.error("Uncaught exception: {}\n{}".format(e, traceback.format_exc()))
+    L.error("Uncaught exception: %s\n%s", e, traceback.format_exc())
 
 
 def find_symbol_ea(project, name):
@@ -341,7 +341,7 @@ def hook_apis(args, project, run_state):
   # use it.
   ea_of_api_table = find_symbol_ea(project, 'DeepState_API')
   if not ea_of_api_table:
-    L.critical("Could not find API table in binary {}", args.binary)
+    L.critical("Could not find API table in binary %s", args.binary)
     return 1
 
   mc = DeepAngr(state=run_state)
@@ -376,8 +376,8 @@ def main_take_over(args, project, takeover_symbol):
       hook_function(project, takeover_ea, TakeOver)
 
   if not takeover_ea:
-    L.critical("Cannot find symbol `{}` in binary `{}`".format(
-        takeover_symbol, args.binary))
+    L.critical("Cannot find symbol `%s` in binary `%s`",
+        takeover_symbol, args.binary)
     return 1
 
   entry_state = project.factory.entry_state(
@@ -395,17 +395,17 @@ def main_take_over(args, project, takeover_symbol):
   try:
     takeover_state = concrete_manager.found[0]
   except:
-    L.critical("Execution never hit `{}` in binary `{}`".format(
+    L.critical("Execution never hit `%s` in binary `%s`",
         takeover_symbol,
-        args.binary))
+        args.binary)
     return 1
 
   try:
     run_state = takeover_state.step().successors[0]
   except:
-    L.critical("Unable to exit from `{}` in binary `{}`".format(
+    L.critical("Unable to exit from `%s` in binary `%s`",
         takeover_symbol,
-        args.binary))
+        args.binary)
     return 1
 
   # Read the API table, which will tell us about the location of various
@@ -414,7 +414,7 @@ def main_take_over(args, project, takeover_symbol):
   # use it.
   ea_of_api_table = find_symbol_ea(project, 'DeepState_API')
   if not ea_of_api_table:
-    L.critical("Could not find API table in binary `{}`".format(args.binary))
+    L.critical("Could not find API table in binary `%s`", args.binary)
     return 1
 
   _, apis = hook_apis(args, project, run_state)
@@ -426,8 +426,7 @@ def main_take_over(args, project, takeover_symbol):
 def main_unit_test(args, project):
   setup_ea = find_symbol_ea(project, 'DeepState_Setup')
   if not setup_ea:
-    L.critical("Cannot find symbol `DeepState_Setup` in binary `{}`".format(
-        args.binary))
+    L.critical("Cannot find symbol `DeepState_Setup` in binary `%s`", args.binary)
     return 1
 
   entry_state = project.factory.entry_state(
@@ -445,8 +444,7 @@ def main_unit_test(args, project):
   try:
     run_state = concrete_manager.found[0]
   except:
-    L.critical("Execution never hit `DeepState_Setup` in binary `{}`".format(
-        args.binary))
+    L.critical("Execution never hit `DeepState_Setup` in binary `%s`", args.binary)
     return 1
 
   # Hook the DeepState API functions.
@@ -457,8 +455,7 @@ def main_unit_test(args, project):
   del mc
 
   if not args.which_test:
-    L.info("Running {} tests across {} workers".format(
-        len(tests), args.num_workers))
+    L.info("Running %d tests across %d workers", len(tests), args.num_workers)
 
     pool = multiprocessing.Pool(processes=max(1, args.num_workers))
     result = []
@@ -482,8 +479,7 @@ def main_unit_test(args, project):
       L.error()
       exit(1)
 
-    L.info("Running `{}` test across {} workers".format(
-      test, args.num_workers))
+    L.info("Running `%s` test across %d workers", test, args.num_workers)
     run_test(project, test[0], apis, run_state)
 
   return 0
@@ -507,8 +503,7 @@ def main():
                                      'puts', 'abort', '__assert_fail',
                                      '__stack_chk_fail'])
   except Exception as e:
-    L.critical("Cannot create Angr instance on binary {}: {}".format(
-        args.binary, e))
+    L.critical("Cannot create Angr instance on binary %s: %s", args.binary, e)
     return 1
 
   if args.take_over:

--- a/bin/deepstate/executors/symex/manticore.py
+++ b/bin/deepstate/executors/symex/manticore.py
@@ -298,19 +298,16 @@ def done_test(_, state, reason):
 
   if str(OUR_TERMINATION_REASON) != str(reason):
     if _is_program_crash(reason):
-      L.info("State {} terminated due to crashing program behavior: {}".format(
-        state._id, reason))
+      L.info("State %s terminated due to crashing program behavior: %s", state._id, reason)
 
       # Don't raise new `TerminateState` exception
       super(DeepManticore, mc).crash_test()
     elif _is_program_exit(reason):
-      L.info("State {} terminated due to program exit: {}".format(
-        state._id, reason))
+      L.info("State %s terminated due to program exit: %s", state._id, reason)
       super(DeepManticore, mc).pass_test()
       #super(DeepManticore, mc).abandon_test()
     else:
-      L.error("State {} terminated due to internal error: {}".format(state._id,
-                                                                     reason))
+      L.error("State %s terminated due to internal error: %s", state._id, reason)
 
       # Don't raise new `TerminateState` exception
       super(DeepManticore, mc).ubandon_test()
@@ -388,8 +385,7 @@ def run_test(state, apis, test, workspace, hook_test=False):
   try:
     do_run_test(state, apis, test, workspace, hook_test)
   except:
-    L.error("Uncaught exception: {}\n{}".format(
-      sys.exc_info()[0], traceback.format_exc()))
+    L.error("Uncaught exception: %s\n%s", sys.exc_info()[0], traceback.format_exc())
 
 
 def run_tests(args, state, apis, workspace):
@@ -398,8 +394,7 @@ def run_tests(args, state, apis, workspace):
   tests = mc.find_test_cases()
 
   if not args.which_test:
-    L.info("Running {} tests across {} workers".format(
-      len(tests), args.num_workers))
+    L.info("Running %d tests across %d workers", len(tests), args.num_workers)
 
     for test in tests:
       run_test(state, apis, test, workspace)
@@ -413,7 +408,7 @@ def run_tests(args, state, apis, workspace):
       L.error("Multiple tests found with same name.")
       exit(1)
 
-    L.info("Running `{}` test across {} workers".format(args.which_test, args.num_workers))
+    L.info("Running `%d` test across %d workers", args.which_test, args.num_workers)
     run_test(state, apis, test[0], workspace)
 
 
@@ -428,15 +423,14 @@ def get_base(m):
     else:
       return 0x555555554000
   else:
-    L.critical("Invalid binary type `{}`".format(e_type))
+    L.critical("Invalid binary type `%s`", e_type)
     exit(1)
 
 def main_takeover(m, args, takeover_symbol):
   takeover_ea = find_symbol_ea(m, takeover_symbol)
   if not takeover_ea:
-    L.critical("Cannot find symbol `{}` in binary `{}`".format(
-      takeover_symbol,
-      args.binary))
+    L.critical("Cannot find symbol `%s` in binary `%s`",
+                  takeover_symbol, args.binary)
     return 1
 
   takeover_state = _make_initial_state(m.binary_path)
@@ -445,7 +439,7 @@ def main_takeover(m, args, takeover_symbol):
 
   ea_of_api_table = find_symbol_ea(m, 'DeepState_API')
   if not ea_of_api_table:
-    L.critical("Could not find API table in binary `{}`".format(args.binary))
+    L.critical("Could not find API table in binary `%s`", args.binary)
     return 1
 
   base = get_base(m)
@@ -468,8 +462,7 @@ def main_takeover(m, args, takeover_symbol):
 def main_unit_test(m, args):
   setup_ea = find_symbol_ea(m, 'DeepState_Setup')
   if not setup_ea:
-    L.critical("Cannot find symbol `DeepState_Setup` in binary `{}`".format(
-      args.binary))
+    L.critical("Cannot find symbol `DeepState_Setup` in binary `%s`", args.binary)
     return 1
 
   setup_state = _make_initial_state(m.binary_path)
@@ -478,7 +471,7 @@ def main_unit_test(m, args):
 
   ea_of_api_table = find_symbol_ea(m, 'DeepState_API')
   if not ea_of_api_table:
-    L.critical("Could not find API table in binary `{}`".format(args.binary))
+    L.critical("Could not find API table in binary `%s`", args.binary)
     return 1
 
   base = get_base(m)
@@ -503,8 +496,7 @@ def main():
   try:
     m = manticore.native.Manticore(args.binary)
   except Exception as e:
-    L.critical("Cannot create Manticore instance on binary {}: {}".format(
-      args.binary, e))
+    L.critical("Cannot create Manticore instance on binary %s: %s", args.binary, e)
     return 1
 
   log.set_verbosity(args.verbosity)

--- a/bin/deepstate/executors/symex/manticore.py
+++ b/bin/deepstate/executors/symex/manticore.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import logging
-logging.basicConfig()
 
 import sys
 try:
@@ -35,8 +34,7 @@ from manticore.native.manticore import _make_initial_state
 
 from deepstate.core import SymexFrontend, TestInfo
 
-L = logging.getLogger("deepstate.mcore")
-L.setLevel(logging.INFO)
+L = logging.getLogger(__name__)
 
 OUR_TERMINATION_REASON = "I DeepState'd it"
 

--- a/push/build_image
+++ b/push/build_image
@@ -5,5 +5,8 @@ set -eu
 IMAGE_NAME="deepstate"
 echo "IMAGE_NAME $IMAGE_NAME"
 
+echo "Building Docker base image..."
+docker build -t deepstate-base -f docker/base/Dockerfile docker/base || exit $?
+
 echo "Building Docker image..."
 docker build -t $IMAGE_NAME -f docker/Dockerfile . || exit $?


### PR DESCRIPTION
Quite a lot of changes. But mostly fixes and enhancements, general idea and most of the code stay the same.

* Make frontends (executors) arguments uniform. Meaning that they share all the basic flags and when some specific fuzzer doesn't support some flag, the flag is just skipped. Only important exceptions are made if necessary, i.e. for angora second, taint binary.
* Add support for `--target_args` (flags passed to deepstate harness) and `--fuzzer_args` (flags passed to the backend fuzzer). Use them like `--target_args a=b abc=x` -> `-a b --abc x`
* Arguments provided by fuzz.py (including inherited from base.py):
  ```
  Guaranteed arguments (have default value):
    - output_test_dir (default: out)
    - mem_limit (default: 50MiB)
    - max_input_size (default: 8192B)
    - fuzzer_args (default: {})
    - blackbox (default: False)
    - post_stats (default: False)

  Optional arguments (may be None):
    - input_seeds
    - dictionary
    - exec_timeout

  Arguments that should not be used by child class:
    - timeout (default: 0)
    - num_workers (default: 1)
    - target_args (default: {})
  ```
* Add few `pre_exec` checks and add some more error handling
* Add `main` method to fuzz.py (since every backend fuzzer main method looks the same)

TODO:
* do something with fuzzer-compilations (json databases as suggested?)
* review `run` method
* pretty printing of statistic in single mode 