### PR TITLE
use `find` for python files searching for pyflakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
           pip install pyflakes mypy
       - name: Lint
         run: |
-          pyflakes bin/deepstate/*.py
-          pyflakes tests/*.py
+          find ./bin -name '*.py' -exec pyflakes "{}" \;
+          find ./tests -name '*.py' -exec pyflakes "{}" \;
           mypy --strict-optional --config-file mypy.ini bin/deepstate
   build:
     strategy:


### PR DESCRIPTION
Currently CI command for `pyflakes` search for python files like `*.py` using bash wildcard. This searches only in the current directory (is not recursive) and thus misses a lot of python files.

After this PR, search is done with `find` command, which is recursive.