### PR TITLE
build deepstate-base in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Build deepstate-base image locally
+        run: |
+          docker build -t deepstate-base -f docker/base/Dockerfile docker/base
       - name: Build and publish container
         uses: elgohr/Publish-Docker-Github-Action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,4 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           dockerfile: docker/Dockerfile
           tag_names: true
+          cache: ${{ github.event_name != 'schedule' }}


### PR DESCRIPTION
A fix for bug in CI introduced by #316. deepstate docker image uses deepstate-base image, which should be build locally in the CI pipeline.

Also adds caching for docker build. The cache is not used for everyday, scheduled builds. So non-reproducible commands (like OS packages installation) may execute sometimes.