### PR TITLE
Update the Docker to Base off of Ubuntu 20.04 (focal) rather than 18.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,16 +11,18 @@ ARG make_j
 RUN bash install_honggfuzz.sh $make_j
 
 # -- Eclipser
-FROM deepstate-base AS Eclipser
-COPY ./docker/install_eclipser.sh ./
-ARG make_j
-RUN bash install_eclipser.sh $make_j
+# REMOVED FOR NOW, SINCE Eclipser does not work on 20.04
+# FROM deepstate-base AS Eclipser
+# COPY ./docker/install_eclipser.sh ./
+# ARG make_j
+# RUN bash install_eclipser.sh $make_j
 
 # -- Angora
-FROM deepstate-base AS Angora
-COPY ./docker/install_angora.sh ./
-ARG make_j
-RUN bash install_angora.sh $make_j
+# ALSO DOES NOT WORK
+# FROM deepstate-base AS Angora
+# COPY ./docker/install_angora.sh ./
+# ARG make_j
+# RUN bash install_angora.sh $make_j
 
 # -- DeepState
 FROM deepstate-base
@@ -29,23 +31,23 @@ ARG make_j
 
 # Angr, Manticore
 RUN echo 'Installing angr and manticore' \
-    && sudo add-apt-repository -y ppa:sri-csl/formal-methods \
+#    && sudo add-apt-repository -y ppa:sri-csl/formal-methods \
     && sudo apt-get -y update \
-    && sudo apt-get -y install yices2 \
+#    && sudo apt-get -y install yices2 \
     && pip3 install z3-solver angr git+git://github.com/trailofbits/manticore.git --user
 
 # Eclipser - not deepstate dependent
-COPY --from=Eclipser /home/user/Eclipser/build $DEPS_DIR/eclipser
-RUN echo 'Eclipser - installing dotnet' \
-    && wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb \
-    && sudo dpkg -i packages-microsoft-prod.deb \
-    && sudo apt-get update \
-    && sudo apt-get install -y dotnet-sdk-2.2
-COPY --from=Eclipser /home/user/.nuget /home/user/.nuget
+# COPY --from=Eclipser /home/user/Eclipser/build $DEPS_DIR/eclipser
+#RUN echo 'Eclipser - installing dotnet' \
+#    && wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb \
+#    && sudo dpkg -i packages-microsoft-prod.deb \
+#    && sudo apt-get update \
+#    && sudo apt-get install -y dotnet-sdk-2.1
+#COPY --from=Eclipser /home/user/.nuget /home/user/.nuget
 
 # Angora part 1 - not deepstate dependent
-COPY --from=Angora /home/user/Angora $DEPS_DIR/angora
-COPY --from=Angora /home/user/clang+llvm $DEPS_DIR/angora/clang+llvm
+#COPY --from=Angora /home/user/Angora $DEPS_DIR/angora
+#COPY --from=Angora /home/user/clang+llvm $DEPS_DIR/angora/clang+llvm
 
 # copy deepstate code here to use cache as much as possible
 COPY . ./deepstate
@@ -54,25 +56,25 @@ WORKDIR ./deepstate
 
 # Angora part 2
 # ignore errors in `make`, because Angora doesn't support 32bit builds
-RUN echo 'Building deepstate with Angora - taint' \
-    && mkdir -p build_angora_taint && cd build_angora_taint \
-    && export PATH="$DEPS_DIR/angora/clang+llvm/bin:$PATH" \
-    && export LD_LIBRARY_PATH="$DEPS_DIR/angora/clang+llvm/lib:$LD_LIBRARY_PATH" \
-    && export USE_TRACK=1 \
-    && export ANGORA_HOME="$DEPS_DIR/angora" \
-    && CXX="$ANGORA_HOME/bin/angora-clang++" CC="$ANGORA_HOME/bin/angora-clang" cmake -DDEEPSTATE_ANGORA=ON ../ \
-    && make -j $make_j -i \
-    && sudo cp ./libdeepstate_taint.a /usr/local/lib/
+#RUN echo 'Building deepstate with Angora - taint' \
+#    && mkdir -p build_angora_taint && cd build_angora_taint \
+#    && export PATH="$DEPS_DIR/angora/clang+llvm/bin:$PATH" \
+#    && export LD_LIBRARY_PATH="$DEPS_DIR/angora/clang+llvm/lib:$LD_LIBRARY_PATH" \
+#    && export USE_TRACK=1 \
+#    && export ANGORA_HOME="$DEPS_DIR/angora" \
+#    && CXX="$ANGORA_HOME/bin/angora-clang++" CC="$ANGORA_HOME/bin/angora-clang" cmake -DDEEPSTATE_ANGORA=ON ../ \
+#    && make -j $make_j -i \
+#    && sudo cp ./libdeepstate_taint.a /usr/local/lib/
 
-RUN echo 'Building deepstate with Angora - fast' \
-    && mkdir -p build_angora_fast && cd build_angora_fast \
-    && export PATH="$DEPS_DIR/angora/clang+llvm/bin:$PATH" \
-    && export LD_LIBRARY_PATH="$DEPS_DIR/angora/clang+llvm/lib:$LD_LIBRARY_PATH" \
-    && export USE_FAST=1 \
-    && export ANGORA_HOME="$DEPS_DIR/angora" \
-    && CXX="$ANGORA_HOME/bin/angora-clang++" CC="$ANGORA_HOME/bin/angora-clang" cmake -DDEEPSTATE_ANGORA=ON ../ \
-    && make -j $make_j -i \
-    && sudo cp ./libdeepstate_fast.a /usr/local/lib/
+#RUN echo 'Building deepstate with Angora - fast' \
+#    && mkdir -p build_angora_fast && cd build_angora_fast \
+#    && export PATH="$DEPS_DIR/angora/clang+llvm/bin:$PATH" \
+#    && export LD_LIBRARY_PATH="$DEPS_DIR/angora/clang+llvm/lib:$LD_LIBRARY_PATH" \
+#    && export USE_FAST=1 \
+#    && export ANGORA_HOME="$DEPS_DIR/angora" \
+#    && CXX="$ANGORA_HOME/bin/angora-clang++" CC="$ANGORA_HOME/bin/angora-clang" cmake -DDEEPSTATE_ANGORA=ON ../ \
+#    && make -j $make_j -i \
+#    && sudo cp ./libdeepstate_fast.a /usr/local/lib/
 
 # general
 RUN echo 'Building deepstate' \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
+
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Set up the non-root user
 RUN apt-get update \
@@ -14,7 +17,7 @@ USER user
 # Install general dependencies
 RUN sudo apt update && sudo apt-get install -y build-essential \
     gcc-multilib g++-multilib cmake \
-    python3-setuptools libffi-dev z3 python3-pip \
+    python python3-setuptools libffi-dev z3 python3-pip \
     git wget lsb-release software-properties-common \
     && sudo rm -rf /var/lib/apt/lists/*
 

--- a/docker/install_eclipser.sh
+++ b/docker/install_eclipser.sh
@@ -12,13 +12,14 @@ sudo apt-get install -y libtool \
     libtool-bin wget automake autoconf \
     bison gdb git apt-transport-https
 
-wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
+wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get update
-sudo apt-get install -y dotnet-sdk-2.2
+sudo apt-get install -y dotnet-sdk-2.1
 sudo rm -rf /var/lib/apt/lists/*
 
 # Install Eclipser
 git clone https://github.com/SoftSec-KAIST/Eclipser \
     && cd Eclipser \
+    && git checkout tags/v1.1 \
     && make -j $1


### PR DESCRIPTION
- Right now, this doesn't work with Eclipser for known reasons

- Angora is also disabled, though I have no investigated why it fails (that is, it might fail on 18.04 also)

- Eclipser probably fails on 18.04 right now as well, just because we directly git clone 2.0, which we probably don't work with