### PR TITLE
Allow OneOf with probability distribution

### DIFF
--- a/examples/OneOfP.cpp
+++ b/examples/OneOfP.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <deepstate/DeepState.hpp>
+
+using namespace deepstate;
+
+TEST(WithProbs, WP) {
+  char out[12];
+  out[11] = '\0';
+  for (int i = 0; i < 10; i++) {
+    OneOfP(
+	   0.1, [&]{out[i] = 'a';},
+	   // a probability of -1 indicates "just use even dist over non-specified"	   
+	   -1, [&]{out[i] = 'b';},
+	   -1, [&]{out[i] = 'c';},
+	   0.6, [&]{out[i] = 'd';});
+  }
+  char a[3] = {'x', 'y', 'z'};
+  out[10] = OneOfP({0.1, 0.1}, a);
+  std::vector<int> pos = {0, 1, 2};
+  int p = OneOfP({-1, -1, 0.9}, pos);
+  out[p] = '!';
+  LOG(TRACE) << "RESULT: '" << out << "'";
+}

--- a/src/include/deepstate/DeepState.hpp
+++ b/src/include/deepstate/DeepState.hpp
@@ -350,6 +350,23 @@ inline static void ForAll(Closure func) {
 #endif
 
 template <typename... FuncTys>
+inline static void OneOfP(double probs[], FuncTys&&... funcs) {
+  if (FLAGS_verbose_reads) {
+    printf("STARTING OneOf CALL\n");
+  }
+  std::function<void(void)> func_arr[sizeof...(FuncTys)] = {funcs...};
+  double P = DeepState_DoubleInRange(0.0, 1.0);
+  unsigned index = 0;
+  while (P < probs[index]) {
+    index++;
+  }
+  func_arr[index]();
+  if (FLAGS_verbose_reads) {
+    printf("FINISHED OneOf CALL\n");
+  }
+}
+
+template <typename... FuncTys>
 inline static void NoSwarmOneOf(FuncTys&&... funcs) {
   if (FLAGS_verbose_reads) {
     printf("STARTING OneOf CALL\n");

--- a/src/include/deepstate/DeepState.hpp
+++ b/src/include/deepstate/DeepState.hpp
@@ -387,7 +387,7 @@ size_t PickProbIndex(std::initializer_list<double> probs, size_t count) {
     DeepState_Abandon("Probability list size greater than number of choices");
   }
   double total = 0.0;
-  vector<double> vecP;
+  std::vector<double> vecP;
   int missing = count - probs.size();
   for (std::initializer_list<double>::iterator it = probs.begin(); it != probs.end(); ++it) {
     if (*it >= 0.0) {

--- a/src/include/deepstate/DeepState.hpp
+++ b/src/include/deepstate/DeepState.hpp
@@ -420,7 +420,7 @@ void SplitArgs(double* probs, func_t *funcs, double firstProb, TyFunc &&firstFun
 template<typename... Args>
 void OneOfP(Args &&... args) {
   constexpr auto length = sizeof...(Args);
-  static_assert((length % 2) == 0);
+  static_assert((length % 2) == 0, "OneOfP expects probability/lambda pairs");
 
   double probs[length];
   func_t funcs[length];


### PR DESCRIPTION
This has some serious limitations.  The syntax is awkward (plist, one of choices); it'd be nicer to have the probabilities be "beside" the choices, of course.  But C/C++ isn't really about native tuples, and that would not work for passing in arrays.

Also, for now, this doesn't get swarmed; assumption is if you gave a distribution, you know what you're doing.  But you can mix this with "plain" OneOfs that do get swarmed.