### PR TITLE
DeepState Ensembler Refactor

### DIFF
--- a/bin/deepstate/core/fuzz.py
+++ b/bin/deepstate/core/fuzz.py
@@ -47,13 +47,16 @@ class FuzzerFrontend(AnalysisBackend):
   Defines a base front-end object for using DeepState to interact with fuzzers.
   """
 
+  # fuzzer-specific configurations
+  ENVVAR: str = "PATH"
   REQUIRE_SEEDS: bool = False
 
+  # configurations for seed synchronization
   PUSH_DIR: str
   PULL_DIR: str
   CRASH_DIR: str
 
-  def __init__(self, envvar: str) -> None:
+  def __init__(self) -> None:
     """
     Create and store variables:
       - fuzzer_exe (fuzzer executable file)
@@ -79,7 +82,6 @@ class FuzzerFrontend(AnalysisBackend):
       - EXECUTABLES dict with keys:
           FUZZER, COMPILER (if compiling) and any executable it will use
 
-    :param envvar: name of envvar to discover executables.
     """
     super(FuzzerFrontend, self).__init__()
 
@@ -87,8 +89,7 @@ class FuzzerFrontend(AnalysisBackend):
       raise FuzzFrontendError("FuzzerFrontend.EXECUTABLES[\"FUZZER\"] not set.")
     self.fuzzer_exe: str = self.EXECUTABLES.pop("FUZZER")
 
-    self.envvar: str = envvar
-    self.env: Optional[str] = os.environ.get(envvar, None)
+    self.env: Optional[str] = os.environ.get(self.ENVVAR, None)
 
     self.search_dirs: List[str] = getattr(self, "SEARCH_DIRS", [])
 
@@ -304,7 +305,7 @@ class FuzzerFrontend(AnalysisBackend):
         return exe_path
 
     raise FuzzFrontendError(f"Executable file `{exe_name}` not found in neither `{self.env}` nor $PATH.\n"
-                            f"Please add path to {self.name} in {self.envvar} env var or in --home_path argument.")
+                            f"Please add path to {self.name} in {self.ENVVAR} env var or in --home_path argument.")
 
 
   def _set_executables(self):

--- a/bin/deepstate/core/fuzz.py
+++ b/bin/deepstate/core/fuzz.py
@@ -626,17 +626,19 @@ class FuzzerFrontend(AnalysisBackend):
     self.proc = None
 
 
-  def run(self, runner: Optional[str] = None, no_exec: bool = False):
+  def run(self, runner: Optional[str] = None, no_exec: bool = False, skip_argparse: bool = False):
     """
     Interface for spawning and executing fuzzer job.
 
     :param runner: if necessary, a runner that is invoked before fuzzer executable (ie `dotnet`)
     :param no_exec: skips pre- and post-processing steps during execution
+    :param skip_argparse: if set, skip argparsing, if already done in any auxiliary executor.
 
     """
 
     # NOTE(alan): we don't use namespace param so we "build up" object attributes when we execute run()
-    super(FuzzerFrontend, self).init_from_dict()
+    if not skip_argparse:
+        super(FuzzerFrontend, self).init_from_dict()
 
     # call pre_exec for any checks/inits before execution.
     if not no_exec:

--- a/bin/deepstate/executors/auxiliary/ensembler.py
+++ b/bin/deepstate/executors/auxiliary/ensembler.py
@@ -44,6 +44,7 @@ class Ensembler(FuzzerFrontend):
   seed synchronization between them.
   """
 
+  NAME = "Ensembler"
   EXECUTABLES = {"FUZZER": "deepstate-ensembler"}
 
   @classmethod
@@ -115,6 +116,10 @@ class Ensembler(FuzzerFrontend):
       L.warn("Output directory does not exist. Creating.")
       os.mkdir(self.output_test_dir)
 
+    if not self.sync_dir:
+        L.warn("No seed synchronization dir specified, using `sync`.")
+        self.sync_dir = "sync"
+
     sync_dir = self.output_test_dir + "/" + self.sync_dir
     if not os.path.isdir(sync_dir):
       L.warn("Sync directory does not exist. Creating.")
@@ -137,7 +142,12 @@ class Ensembler(FuzzerFrontend):
     if ret_all:
       return [subclass() for subclass in FuzzerFrontend.__subclasses__()]
     else:
-      return [AFL(), Honggfuzz(), Angora(), Eclipser()]
+      return [
+        AFL(envvar="AFL_HOME"), 
+        Honggfuzz(envvar="HONGGFUZZ_HOME"),
+        Angora(envvar="ANGORA_HOME"),
+        Eclipser(envvar="ECLIPSER_HOME")
+      ]
 
 
   def _get_tests(self, tests):
@@ -365,7 +375,7 @@ class Ensembler(FuzzerFrontend):
 
 
 def main():
-  ensembler = Ensembler()
+  ensembler = Ensembler(envvar="PATH")
 
   # parse arguments and provision ensembler
   ensembler.parse_args()

--- a/bin/deepstate/executors/auxiliary/ensembler.py
+++ b/bin/deepstate/executors/auxiliary/ensembler.py
@@ -285,7 +285,7 @@ class Ensembler(FuzzerFrontend):
         "output_test_dir": "{}/{}_{}_out".format(self.output_test_dir, str(fuzzer), _rand_id()),
         "dictionary": None,
         "max_input_size": self.max_input_size if self.max_input_size else 8192,
-        "mem_limit": 50,
+        "mem_limit": "none",
         "which_test": self.which_test,
         "target_args": self.target_args,
 
@@ -338,12 +338,12 @@ class Ensembler(FuzzerFrontend):
 
       fuzzer.init_from_dict(fuzzer_args)
 
-      # sets compiler and no_exec params before execution
+      # sets compiler, no_exec and skip_argparse params before execution
       # Eclipser requires `dotnet` to be invoked before fuzzer executable.
       if isinstance(fuzzer, Eclipser):
-        args = ("dotnet", True)
+        args = ("dotnet", True, True)
       else:
-        args = (None, True)
+        args = (None, True, True)
 
 
       L.info("Initialized %s for ensemble-fuzzing and spinning up child proc.", fuzzer)
@@ -355,11 +355,12 @@ class Ensembler(FuzzerFrontend):
     # TODO(alan): fix up delayed reporter; try not to have an individual proc run for
     # reporting
     if not self.no_global:
-      L.info("Starting up child proc for global stats reporting.")
+      L.info("Creating child proc for global stats reporting.")
       report_proc = Process(target=self.report, args=())
       procs.append(report_proc)
 
     for proc in procs:
+      L.info("Starting child proc for fuzzing.")
       proc.start()
 
     # sleep until fuzzers finalize initialization, approx 5 seconds

--- a/bin/deepstate/executors/auxiliary/ensembler.py
+++ b/bin/deepstate/executors/auxiliary/ensembler.py
@@ -142,12 +142,7 @@ class Ensembler(FuzzerFrontend):
     if ret_all:
       return [subclass() for subclass in FuzzerFrontend.__subclasses__()]
     else:
-      return [
-        AFL(envvar="AFL_HOME"), 
-        Honggfuzz(envvar="HONGGFUZZ_HOME"),
-        Angora(envvar="ANGORA_HOME"),
-        Eclipser(envvar="ECLIPSER_HOME")
-      ]
+      return [AFL(), Honggfuzz(), Angora(), Eclipser()]
 
 
   def _get_tests(self, tests):
@@ -375,7 +370,7 @@ class Ensembler(FuzzerFrontend):
 
 
 def main():
-  ensembler = Ensembler(envvar="PATH")
+  ensembler = Ensembler()
 
   # parse arguments and provision ensembler
   ensembler.parse_args()

--- a/bin/deepstate/executors/fuzz/afl.py
+++ b/bin/deepstate/executors/fuzz/afl.py
@@ -29,10 +29,9 @@ class AFL(FuzzerFrontend):
   """ Defines AFL fuzzer frontend """
 
   NAME = "AFL"
-  EXECUTABLES = {"FUZZER": "afl-fuzz",
-                  "COMPILER": "afl-clang++"
-                  }
+  EXECUTABLES = {"FUZZER": "afl-fuzz", "COMPILER": "afl-clang++"}
 
+  ENVVAR = "AFL_HOME"
   REQUIRE_SEEDS = True
 
   PUSH_DIR = os.path.join("sync_dir", "queue")
@@ -72,7 +71,7 @@ class AFL(FuzzerFrontend):
     # check if core dump pattern is set as `core`
     if os.path.isfile("/proc/sys/kernel/core_pattern"):
       with open("/proc/sys/kernel/core_pattern") as f:
-        if not "core" in f.read():
+        if f.read().strip() != "core":
           raise FuzzFrontendError("No core dump pattern set. Execute 'echo core | sudo tee /proc/sys/kernel/core_pattern'")
 
     # check if CPU scaling governor is set to `performance`
@@ -197,7 +196,7 @@ class AFL(FuzzerFrontend):
 
 
 def main():
-  fuzzer = AFL(envvar="AFL_HOME")
+  fuzzer = AFL()
   return fuzzer.main()
 
 

--- a/bin/deepstate/executors/fuzz/angora.py
+++ b/bin/deepstate/executors/fuzz/angora.py
@@ -39,6 +39,7 @@ class Angora(FuzzerFrontend):
                   "CLANG_COMPILER": "clang++"
                   }
 
+  ENVVAR = "ANGORA_HOME"
   REQUIRE_SEEDS = True
 
   PUSH_DIR = os.path.join("sync_dir", "queue")
@@ -276,7 +277,7 @@ class Angora(FuzzerFrontend):
 
 
 def main():
-  fuzzer = Angora(envvar="ANGORA_HOME")
+  fuzzer = Angora()
   return fuzzer.main()
 
 

--- a/bin/deepstate/executors/fuzz/eclipser.py
+++ b/bin/deepstate/executors/fuzz/eclipser.py
@@ -40,6 +40,7 @@ class Eclipser(FuzzerFrontend):
                   "RUNNER": "dotnet"
                   }
 
+  ENVVAR = "ECLIPSER_HOME"
   REQUIRE_SEEDS = False
 
   PUSH_DIR = os.path.join("sync_dir", "queue")
@@ -199,7 +200,7 @@ class Eclipser(FuzzerFrontend):
 
 def main():
   try:
-    fuzzer = Eclipser(envvar="ECLIPSER_HOME")
+    fuzzer = Eclipser()
     fuzzer.parse_args()
     fuzzer.run(runner=fuzzer.EXECUTABLES["RUNNER"])
     return 0

--- a/bin/deepstate/executors/fuzz/libfuzzer.py
+++ b/bin/deepstate/executors/fuzz/libfuzzer.py
@@ -30,6 +30,7 @@ class LibFuzzer(FuzzerFrontend):
                   "COMPILER": "clang++"
                   }
 
+  ENVVAR = "LIBFUZZER_HOME"
   REQUIRE_SEEDS = False
 
   PUSH_DIR = os.path.join("sync_dir", "queue")
@@ -166,7 +167,7 @@ class LibFuzzer(FuzzerFrontend):
 
 
 def main():
-  fuzzer = LibFuzzer(envvar="LIBFUZZER_HOME")
+  fuzzer = LibFuzzer()
   return fuzzer.main()
 
 


### PR DESCRIPTION
Introduced some immediate fixes to the syntax errors in the ensemble fuzzer, but will need to spend some more time later to see what other issues arise and fixes are needed.

Things that can be incorporated:

* Rather than pass a `envvar` keyword argument to each executor, parametrize it as an attribute in the fuzzer object itself (ie `ENVVAR = "AFL_HOME"` ) so that the constructors take no arguments across all the executors.
* Long-term, may not be something that's needed now: refactor `AnalysisBackend` to be an abstract base class (`abc.ABC`)