### PR TITLE
Downgrade Docker 16.04 to upgrade llvm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,18 +93,11 @@ if (DEEPSTATE_ANGORA)
   string(FIND "${CMAKE_C_COMPILER}" "angora-clang" _angora_found)
   if(_angora_found EQUAL -1)
     message(FATAL_ERROR "DeepState's Angora mode requires the angora-clang C compiler.")
-  elseif(CMAKE_C_COMPILER_VERSION VERSION_LESS "4.0.0" OR CMAKE_C_COMPILER_VERSION VERSION_GREATER "7.1.0")
-    message("X " ${CMAKE_C_COMPILER})
-    message(FATAL_ERROR "DeepState's Angora mode requires the main compiler to be clang 4.0.0-7.1.0\n"
-                        "export PATH to \"$ANGORA_HOME/clang+llvm/bin:$PATH\"")
   endif()
 
   string(FIND "${CMAKE_CXX_COMPILER}" "angora-clang++" _angora_found)
   if(_angora_found EQUAL -1)
     message(FATAL_ERROR "DeepState's Angora mode requires the angora-clang++ C++ compiler.")
-  elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.0.0" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "7.1.0")
-    message(FATAL_ERROR "DeepState's Angora mode requires the main compiler to be clang++ 4.0.0-7.1.0\n"
-                        "export PATH to \"$ANGORA_HOME/clang+llvm/bin:$PATH\"")
   endif()
 endif()
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 FROM deepstate-base AS AFL
 COPY ./docker/install_afl.sh ./
 ARG make_j
-RUN bash install_afl.sh $make_j
+RUN conda activate deepstate_env && bash install_afl.sh $make_j
 
 # -- Honggfuzz
 FROM deepstate-base AS Honggfuzz
@@ -20,7 +20,7 @@ RUN bash install_eclipser.sh $make_j
 FROM deepstate-base AS Angora
 COPY ./docker/install_angora.sh ./
 ARG make_j
-RUN bash install_angora.sh $make_j
+RUN conda activate deepstate_env && bash install_angora.sh $make_j
 
 # -- DeepState
 FROM deepstate-base
@@ -29,10 +29,15 @@ ARG make_j
 
 # Angr, Manticore
 RUN echo 'Installing angr and manticore' \
+    && sudo apt -y update \
     && sudo add-apt-repository -y ppa:sri-csl/formal-methods \
     && sudo apt-get -y update \
     && sudo apt-get -y install yices2 \
-    && pip3 install z3-solver angr git+git://github.com/trailofbits/manticore.git --user
+    && conda activate deepstate_env \
+    && pip install z3-solver angr git+git://github.com/trailofbits/manticore.git --user
+
+RUN conda activate deepstate_env \
+    && pip install z3-solver angr git+git://github.com/trailofbits/manticore.git --user
 
 # Eclipser - not deepstate dependent
 COPY --from=Eclipser /home/user/Eclipser/build $DEPS_DIR/eclipser
@@ -76,6 +81,7 @@ RUN echo 'Building deepstate with Angora - fast' \
 
 # general
 RUN echo 'Building deepstate' \
+    && conda activate deepstate_env \
     && mkdir -p ./build_deepstate && cd ./build_deepstate \
     && CXX=clang++ CC=clang cmake ../ \
     && make -j $make_j \
@@ -83,6 +89,7 @@ RUN echo 'Building deepstate' \
 
 # libFuzzer
 RUN echo 'Building deepstate with libFuzzer' \
+    && conda activate deepstate_env \
     && mkdir -p build_libfuzzer && cd build_libfuzzer \
     && CXX=clang++ CC=clang cmake -DDEEPSTATE_LIBFUZZER=ON ../ \
     && make -j $make_j \
@@ -91,6 +98,7 @@ RUN echo 'Building deepstate with libFuzzer' \
 # AFL
 COPY --from=AFL /home/user/afl-2.52b $DEPS_DIR/afl
 RUN echo 'Building deepstate with AFL' \
+    && conda activate deepstate_env \
     && mkdir -p build_afl && cd build_afl \
     && export AFL_HOME="$DEPS_DIR/afl" \
     && CXX="$AFL_HOME/afl-clang++" CC="$AFL_HOME/afl-clang" cmake -DDEEPSTATE_AFL=ON ../ \
@@ -102,6 +110,7 @@ COPY --from=Honggfuzz /home/user/honggfuzz $DEPS_DIR/honggfuzz
 RUN sudo apt-get update && sudo apt-get -y install libunwind-dev
 RUN echo "HELLO SAILOR" \
 RUN echo 'Building deepstate with Honggfuzz' \
+    && conda activate deepstate_env \
     && mkdir -p build_honggfuzz && cd build_honggfuzz \
     && export HONGGFUZZ_HOME="$DEPS_DIR/honggfuzz" \
     && CXX="$HONGGFUZZ_HOME/hfuzz_cc/hfuzz-clang++" CC="$HONGGFUZZ_HOME/hfuzz_cc/hfuzz-clang" cmake -DDEEPSTATE_HONGGFUZZ=ON ../ \

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,4 +1,28 @@
-FROM ubuntu:18.04
+FROM ubuntu:16.04
+
+SHELL ["/bin/bash", "-lc"]
+
+RUN apt-get update &&       \
+    apt-get install -y      \
+        curl                \
+        gcc                 \
+        g++                 \
+        git                 \
+        libgl1-mesa-dev     \
+    &&                      \
+    rm -rf /var/cache/apt/*
+
+RUN curl -sLo /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh &&    \
+    chmod +x /tmp/miniconda.sh &&                                                                           \
+    /tmp/miniconda.sh -b -p /opt/conda &&                                                                   \
+    rm /tmp/miniconda.sh &&                                                                                 \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh &&                                      \
+    echo '. /opt/conda/etc/profile.d/conda.sh' >> /etc/bash.bashrc
+
+RUN git config --system http.sslCAInfo /etc/ssl/certs/ca-certificates.crt &&        \
+    echo 'ssl_verify: /etc/ssl/certs/ca-certificates.crt' > /opt/conda/.condarc &&  \
+    echo 'always_yes: true' >> /opt/conda/.condarc &&                               \
+    conda update conda
 
 # Set up the non-root user
 RUN apt-get update \
@@ -6,19 +30,39 @@ RUN apt-get update \
     && useradd -ms /bin/bash user && echo "user:user" | chpasswd && adduser user sudo
 COPY /sudoers.txt /etc/sudoers
 
+# Make RUN commands use `bash --login`:
+SHELL ["/bin/bash", "--login", "-c"]
+
+RUN conda create -c conda-forge -n deepstate_env python=3.7 pip setuptools
+
+# Initialize conda in bash config fiiles:
+RUN conda init bash
+
 # Switch to permissioned user
 WORKDIR /home/user
 RUN chown -R user:user /home/user
 USER user
 
-# Install general dependencies
-RUN sudo apt update && sudo apt-get install -y build-essential \
-    gcc-multilib g++-multilib cmake \
-    python3-setuptools libffi-dev z3 python3-pip \
-    git wget lsb-release software-properties-common \
-    && sudo rm -rf /var/lib/apt/lists/*
+# Make RUN commands use `bash --login`:
+SHELL ["/bin/bash", "--login", "-c"]
 
-ENV LLVM_VER=9
+# Initialize conda in bash config fiiles:
+RUN conda init bash
+
+RUN conda activate deepstate_env
+
+# Install general dependencies
+RUN sudo apt update \
+    && sudo apt-get remove python3-apt \
+    && sudo apt-get install -y build-essential python3-apt \
+    gcc-multilib g++-multilib cargo libffi-dev z3 \
+    git wget lsb-release software-properties-common \
+    apt-transport-https ca-certificates cmake \
+    && sudo rm -rf /var/lib/apt/lists/*
+#
+# RUN sudo ln -s /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
+#
+ENV LLVM_VER=11
 
 # Install LLVM
 RUN wget https://apt.llvm.org/llvm.sh \
@@ -26,13 +70,13 @@ RUN wget https://apt.llvm.org/llvm.sh \
     && sudo ./llvm.sh $LLVM_VER
 
 RUN sudo apt-get update && sudo apt-get -y install libllvm-$LLVM_VER-ocaml-dev \
-    libllvm$LLVM_VER llvm-$LLVM_VER llvm-$LLVM_VER-dev \
+    libllvm$LLVM_VER llvm-$LLVM_VER llvm-$LLVM_VER-dev libz-dev \
     llvm-$LLVM_VER-doc llvm-$LLVM_VER-examples llvm-$LLVM_VER-runtime \
     clang-$LLVM_VER clang-tools-$LLVM_VER clang-$LLVM_VER-doc \
     libclang-common-$LLVM_VER-dev libclang-$LLVM_VER-dev libclang1-$LLVM_VER \
-    clang-format-$LLVM_VER python-clang-$LLVM_VER clangd-$LLVM_VER \
+    clang-format-$LLVM_VER python3-clang-$LLVM_VER clangd-$LLVM_VER \
     libfuzzer-$LLVM_VER-dev libc++-$LLVM_VER-dev libc++abi-$LLVM_VER-dev \
     lld-$LLVM_VER lldb-$LLVM_VER
 
-RUN sudo ln -s $(which clang-$LLVM_VER) /usr/bin/clang 
-RUN sudo ln -s $(which clang++-$LLVM_VER) /usr/bin/clang++ 
+RUN sudo ln -s $(which clang-$LLVM_VER) /usr/bin/clang
+RUN sudo ln -s $(which clang++-$LLVM_VER) /usr/bin/clang++

--- a/docker/install_angora.sh
+++ b/docker/install_angora.sh
@@ -12,7 +12,8 @@ sudo apt-get install -y rustc \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # set proper LLVM version
-export LLVM_VER=7.0.0
+export LLVM_VER=11.0.1
+export LINUX_VER=ubuntu-16.04
 export PATH="$(pwd)/clang+llvm/bin:$PATH"
 export LD_LIBRARY_PATH="$(pwd)/clang+llvm/lib:$LD_LIBRARY_PATH"
 

--- a/docker/install_honggfuzz.sh
+++ b/docker/install_honggfuzz.sh
@@ -2,11 +2,17 @@
 set -e
 
 # Install dependencies
-sudo apt-get update && sudo apt-get install -y binutils-dev \
-    libunwind-dev \
+sudo apt-get -y update && sudo apt-get install -y \
+    gcc \
+    git \
+    make \
+    pkg-config \
+  	libunwind8-dev \
+  	binutils-dev \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Install Honggfuzz
 git clone https://github.com/google/honggfuzz \
     && cd honggfuzz \
+    && git checkout tags/2.1 -b 2.1 \
     && make -j $1


### PR DESCRIPTION
Updates the dockerfile to build with an updated llvm package. Unfortunately this requires that the ubuntu container be downgraded to 16.04 because llvm stopped supporting 18.04 seemingly.

There is also the addition of a conda env into the image which isn't ideal but this was the easiest way to update the python version on 16.04