### PR TITLE
DeepState on Windows with MinGW

### DIFF
--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -272,7 +272,7 @@ extern void *DeepState_Malloc(size_t num_bytes);
 extern void *DeepState_GCMalloc(size_t num_bytes);
 
 /* Returns the path to a testcase without parsing to any aforementioned types */
-extern const char *DeepState_InputPath(char *testcase_path);
+extern char *DeepState_InputPath(const char* testcase_path);
 
 /* Portable and architecture-independent memory scrub without dead store elimination. */
 extern void *DeepState_MemScrub(void *pointer, size_t data_size);

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -843,7 +843,6 @@ DeepState_ForkAndRunTest(struct DeepState_TestInfo *test) {
     }
 
     /* If we exited normally, the status code tells us if the test passed. */
-    int wstatus = 0;
     if (FLAGS_fork) {
       waitpid(test_pid, &wstatus, 0);
       return (enum DeepState_TestRunResult) wstatus;

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -627,15 +627,6 @@ static void DeepState_InitInputFromFile(const char *path) {
     DeepState_Abandon("Tried to get file descriptor for invalid stream");
   }
 
-  #if defined(_WIN32) || defined(_MSC_VER)
-    /* TODO: Check availability of the input file */
-  #elif defined(__unix)
-    struct stat stat_buf;
-    if (fstat(fd, &stat_buf) < 0) {
-      DeepState_Abandon("Unable to access input file");
-    }; 
-  #endif
-
   fseek(fp, 0L, SEEK_END);
   size_t to_read = ftell(fp);
   fseek(fp, 0L, SEEK_SET);
@@ -1155,7 +1146,10 @@ static int DeepState_RunSingleSavedTestDir(void) {
     snprintf(path, path_len, "%s/%s", FLAGS_input_test_files_dir, dp->d_name);
 
     #if defined(_WIN32) || defined(_MSC_VER)
-    /* TODO: implement path check for Windows */
+      DWORD file_attributes = GetFileAttributes(path);
+      if (file_attributes == INVALID_FILE_ATTRIBUTES || (file_attributes & FILE_ATTRIBUTE_DIRECTORY) ){
+        continue;
+      }
     #elif defined(__unix)
       stat(path, &path_stat);
       if (!S_ISREG(path_stat.st_mode)) {

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -46,6 +46,9 @@ DEFINE_bool(verbose_reads, ExecutionGroup, false, "Report on bytes being read du
 DEFINE_int(min_log_level, ExecutionGroup, 0, "Minimum level of logging to output (default 0, 0=debug, 1=trace, 2=info, ...).");
 DEFINE_int(timeout, ExecutionGroup, 3600, "Timeout for brute force fuzzing.");
 DEFINE_uint(num_workers, ExecutionGroup, 1, "Number of workers to spawn for testing and test generation.");
+#if defined(_WIN32) || defined(_MSC_VER)
+DEFINE_bool(direct_run, ExecutionGroup, false, "Run test function directly.");
+#endif
 
 /* Fuzzing and symex related options, baked in to perform analysis-related tasks without auxiliary tools */
 DEFINE_bool(fuzz, AnalysisGroup, false, "Perform brute force unguided fuzzing.");
@@ -115,17 +118,39 @@ static void DeepState_SetTestAbandoned(const char *reason) {
 }
 
 void DeepState_AllocCurrentTestRun(void) {
-  int mem_prot = PROT_READ | PROT_WRITE;
-  int mem_vis = MAP_ANONYMOUS | MAP_SHARED;
-  void *shared_mem = mmap(NULL, sizeof(struct DeepState_TestRunInfo), mem_prot,
-                          mem_vis, 0, 0);
+  #if defined(_WIN32) || defined(_MSC_VER) 
+    HANDLE shared_mem_handle = INVALID_HANDLE_VALUE;
+    
+    shared_mem_handle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 
+                    0, sizeof(struct DeepState_TestRunInfo), "DeepState_CurrentTestRun");
+    if (!shared_mem_handle){
+      DeepState_LogFormat(DeepState_LogError, "Unable to map shared memory (%d)", GetLastError());
+      exit(1);
+    }
 
-  if (shared_mem == MAP_FAILED) {
-    DeepState_Log(DeepState_LogError, "Unable to map shared memory");
-    exit(1);
-  }
+	  struct DeepState_TestRunInfo *shared_mem = (struct DeepState_TestRunInfo*) MapViewOfFile(shared_mem_handle, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(struct DeepState_TestRunInfo));
+    if (!shared_mem){
+      DeepState_LogFormat(DeepState_LogError, "Unable to map shared memory (%d)", GetLastError());
+      exit(1);
+    }
 
-  DeepState_CurrentTestRun = (struct DeepState_TestRunInfo *) shared_mem;
+    DeepState_CurrentTestRun = (struct DeepState_TestRunInfo *) shared_mem;
+
+  #elif defined(__unix)
+
+    int mem_prot = PROT_READ | PROT_WRITE;
+    int mem_vis = MAP_ANONYMOUS | MAP_SHARED;
+    void *shared_mem = mmap(NULL, sizeof(struct DeepState_TestRunInfo), mem_prot,
+                            mem_vis, 0, 0);
+
+    if (shared_mem == MAP_FAILED) {
+      DeepState_Log(DeepState_LogError, "Unable to map shared memory");
+      exit(1);
+    }
+
+    DeepState_CurrentTestRun = (struct DeepState_TestRunInfo *) shared_mem;
+  #endif
+
 }
 
 static void DeepState_InitCurrentTestRun(struct DeepState_TestInfo *test) {
@@ -521,34 +546,24 @@ int DeepState_Bool(void) {
  * to generate some specialized structured type. */
 const char * DeepState_InputPath(char *testcase_path) {
 
-  struct stat statbuf;
   char *abspath;
 
   /* Use specified path if no --input_test* flag specified. Override if --input_* args specified. */
   if (testcase_path) {
     if (!HAS_FLAG_input_test_file && !HAS_FLAG_input_test_files_dir) {
-      abspath = realpath(testcase_path, NULL);
+      abspath = testcase_path;
     }
   }
 
   /* Prioritize using CLI-specified input paths, for the sake of fuzzing */
   if (HAS_FLAG_input_test_file) {
-    abspath = realpath(FLAGS_input_test_file, NULL);
+    abspath = FLAGS_input_test_file;
   } else if (HAS_FLAG_input_test_files_dir) {
-    abspath = realpath(FLAGS_input_test_files_dir, NULL);
+    abspath = FLAGS_input_test_files_dir;
   } else {
     DeepState_Abandon("No usable path specified for DeepState_InputPath.");
   }
 
-  if (stat(abspath, &statbuf) != 0) {
-    DeepState_Abandon("Specified input path does not exist.");
-  }
-
-  if (HAS_FLAG_input_test_files_dir) {
-    if (!S_ISDIR(statbuf.st_mode)) {
-      DeepState_Abandon("Specified input directory is not a directory.");
-    }
-  }
 
   DeepState_LogFormat(DeepState_LogInfo, "Using `%s` as input path.", abspath);
   return abspath;
@@ -825,102 +840,118 @@ void DeepState_Warn_srand(unsigned int seed) {
 
 void DeepState_RunSavedTakeOverCases(jmp_buf env,
                                      struct DeepState_TestInfo *test) {
-  int num_failed_tests = 0;
-  const char *test_case_dir = FLAGS_input_test_dir;
+  #if defined(__unix)
+    int num_failed_tests = 0;
+    const char *test_case_dir = FLAGS_input_test_dir;
 
-  DIR *dir_fd = opendir(test_case_dir);
-  if (dir_fd == NULL) {
-    DeepState_LogFormat(DeepState_LogInfo,
-                        "Skipping test `%s`, no saved test cases",
-                        test->test_name);
-    return;
-  }
+    DIR *dir_fd = opendir(test_case_dir);
+    if (dir_fd == NULL) {
+      DeepState_LogFormat(DeepState_LogInfo,
+                          "Skipping test `%s`, no saved test cases",
+                          test->test_name);
+      return;
+    }
 
-  struct dirent *dp;
+    struct dirent *dp;
 
-  /* Read generated test cases and run a test for each file found. */
-  while ((dp = readdir(dir_fd)) != NULL) {
-    if (DeepState_IsTestCaseFile(dp->d_name)) {
-      DeepState_InitCurrentTestRun(test);
+    /* Read generated test cases and run a test for each file found. */
+    while ((dp = readdir(dir_fd)) != NULL) {
+      if (DeepState_IsTestCaseFile(dp->d_name)) {
+        DeepState_InitCurrentTestRun(test);
 
-      pid_t case_pid = fork();
-      if (!case_pid) {
-        DeepState_Begin(test);
+        pid_t case_pid = fork();
+        if (!case_pid) {
+          DeepState_Begin(test);
 
-        size_t path_len = 2 + sizeof(char) * (strlen(test_case_dir) +
-                                              strlen(dp->d_name));
-        char *path = (char *) malloc(path_len);
-        if (path == NULL) {
-          DeepState_Abandon("Error allocating memory");
+          size_t path_len = 2 + sizeof(char) * (strlen(test_case_dir) +
+                                                strlen(dp->d_name));
+          char *path = (char *) malloc(path_len);
+          if (path == NULL) {
+            DeepState_Abandon("Error allocating memory");
+          }
+          snprintf(path, path_len, "%s/%s", test_case_dir, dp->d_name);
+          DeepState_InitInputFromFile(path);
+          free(path);
+
+          longjmp(env, 1);
         }
-        snprintf(path, path_len, "%s/%s", test_case_dir, dp->d_name);
-        DeepState_InitInputFromFile(path);
-        free(path);
 
-        longjmp(env, 1);
-      }
+        int wstatus;
+        waitpid(case_pid, &wstatus, 0);
 
-      int wstatus;
-      waitpid(case_pid, &wstatus, 0);
-
-      /* If we exited normally, the status code tells us if the test passed. */
-      if (WIFEXITED(wstatus)) {
-        switch (DeepState_CurrentTestRun->result) {
-        case DeepState_TestRunPass:
-          DeepState_LogFormat(DeepState_LogTrace,
-                              "Passed: TakeOver test with data from `%s`",
-                              dp->d_name);
-          break;
-        case DeepState_TestRunFail:
-          DeepState_LogFormat(DeepState_LogError,
-                              "Failed: TakeOver test with data from `%s`",
-                              dp->d_name);
-          break;
-        case DeepState_TestRunCrash:
+        /* If we exited normally, the status code tells us if the test passed. */
+        if (WIFEXITED(wstatus)) {
+          switch (DeepState_CurrentTestRun->result) {
+          case DeepState_TestRunPass:
+            DeepState_LogFormat(DeepState_LogTrace,
+                                "Passed: TakeOver test with data from `%s`",
+                                dp->d_name);
+            break;
+          case DeepState_TestRunFail:
+            DeepState_LogFormat(DeepState_LogError,
+                                "Failed: TakeOver test with data from `%s`",
+                                dp->d_name);
+            break;
+          case DeepState_TestRunCrash:
+            DeepState_LogFormat(DeepState_LogError,
+                                "Crashed: TakeOver test with data from `%s`",
+                                dp->d_name);
+            break;
+          case DeepState_TestRunAbandon:
+            DeepState_LogFormat(DeepState_LogError,
+                                "Abandoned: TakeOver test with data from `%s`",
+                                dp->d_name);
+            break;
+          default:  /* Should never happen */
+            DeepState_LogFormat(DeepState_LogError,
+                                "Error: Invalid test run result %d from `%s`",
+                                DeepState_CurrentTestRun->result, dp->d_name);
+          }
+        } else {
+          /* If here, we exited abnormally but didn't catch it in the signal
+          * handler, and thus the test failed due to a crash. */
           DeepState_LogFormat(DeepState_LogError,
                               "Crashed: TakeOver test with data from `%s`",
                               dp->d_name);
-          break;
-        case DeepState_TestRunAbandon:
-          DeepState_LogFormat(DeepState_LogError,
-                              "Abandoned: TakeOver test with data from `%s`",
-                              dp->d_name);
-          break;
-        default:  /* Should never happen */
-          DeepState_LogFormat(DeepState_LogError,
-                              "Error: Invalid test run result %d from `%s`",
-                              DeepState_CurrentTestRun->result, dp->d_name);
         }
-      } else {
-        /* If here, we exited abnormally but didn't catch it in the signal
-         * handler, and thus the test failed due to a crash. */
-        DeepState_LogFormat(DeepState_LogError,
-                            "Crashed: TakeOver test with data from `%s`",
-                            dp->d_name);
       }
     }
-  }
-  closedir(dir_fd);
+    closedir(dir_fd);
+  #endif
+
+  /* If here the system is not unix based, and thus exit with an error. */
+  DeepState_LogFormat(DeepState_LogError,
+                      "Error: takeover works only on Unix based systems.");
+  return -1;
 }
 
 int DeepState_TakeOver(void) {
-  struct DeepState_TestInfo test = {
-    .prev = NULL,
-    .test_func = NULL,
-    .test_name = "__takeover_test",
-    .file_name = "__takeover_file",
-    .line_number = 0,
-  };
 
-  DeepState_AllocCurrentTestRun();
+  #if defined(__unix)
+    struct DeepState_TestInfo test = {
+      .prev = NULL,
+      .test_func = NULL,
+      .test_name = "__takeover_test",
+      .file_name = "__takeover_file",
+      .line_number = 0,
+    };
 
-  jmp_buf env;
-  if (!setjmp(env)) {
-    DeepState_RunSavedTakeOverCases(env, &test);
-    exit(0);
-  }
+    DeepState_AllocCurrentTestRun();
 
-  return 0;
+    jmp_buf env;
+    if (!setjmp(env)) {
+      DeepState_RunSavedTakeOverCases(env, &test);
+      exit(0);
+    }
+
+    return 0;
+  #endif
+
+  /* If here the system is not unix based, and thus exit with an error. */
+  DeepState_LogFormat(DeepState_LogError,
+                      "Error: takeover works only on Unix based systems.");
+  return -1;
+
 }
 
 /* Right now "fake" a hexdigest by just using random bytes.  Not ideal. */
@@ -1225,7 +1256,7 @@ void __stack_chk_fail(void) {
 
 #ifndef LIBFUZZER
 #ifndef HEADLESS
-__attribute__((weak))
+
 int main(int argc, char *argv[]) {
   int ret = 0;
   DeepState_Setup();

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -1328,6 +1328,9 @@ void DeepState_RunSingle(){
 #ifndef LIBFUZZER
 #ifndef HEADLESS
 
+#if defined(__unix)
+__attribute__((weak))
+#endif
 int main(int argc, char *argv[]) {
   int ret = 0;
   DeepState_Setup();

--- a/src/lib/DeepState.c
+++ b/src/lib/DeepState.c
@@ -1254,6 +1254,37 @@ void __stack_chk_fail(void) {
   __builtin_unreachable();
 }
 
+/* Runs a single test. This function is intended to be executed within a new 
+Windows process. */
+void DeepState_RunSingle(){
+  struct DeepState_TestInfo *test = DeepState_FirstTest(); 
+
+  /* Seek for the TEST to run */
+  for (test = DeepState_FirstTest(); test != NULL; test = test->prev) {
+    if (HAS_FLAG_input_which_test) {
+      if (strcmp(FLAGS_input_which_test, test->test_name) == 0) {
+        break;
+      }
+    } else {
+      DeepState_LogFormat(DeepState_LogWarning,
+			  "No test specified, defaulting to first test defined (%s)",
+			  test->test_name);
+      break;
+    }
+  }
+
+  if (test == NULL) {
+    DeepState_LogFormat(DeepState_LogInfo,
+                        "Could not find matching test for %s",
+                        FLAGS_input_which_test);
+    return;
+  }
+
+  /* Run the test */
+  DeepState_RunTest(test);
+
+}
+
 #ifndef LIBFUZZER
 #ifndef HEADLESS
 


### PR DESCRIPTION
# Description
This pull request aims to expand the DeepState framework for Windows platforms so that more people can utilize it. This is primarily done to port the [RcppDeepState](https://github.com/FabrizioSandri/RcppDeepState) fuzz testing framework created in R to the Windows platform. 

# Changes 
DeepState requires a lot of POSIX constructs, such as `fork`, `wait`,and `mmap`, which are not supported by Windows. This is the biggest challenge in porting DeepState to Windows. Let's step-by-step assess each change.


### `DeepState_AllocCurrentTestRun`. 
This function allocates some space for the `DeepState_CurrentTestRun` structure using `mmap` into a shared virtual address space. This allows the child process running the test to access the parent's `DeepState_CurrentTestRun` when running with `fork`. 


The Microsoft official documentation explains how to use memory-mapped files instead of the POSIX function `mmap` in Windows by using `CreateFileMapping` and `MapViewOfFile` [[1]](#references). By doing this, the structure `DeepState_CurrentTestRun` will be accessible by both the parent and child processes. 


### `DeepState_ForkAndRunTest` and `DeepState_RunTestWin`.
It is the responsibility of `DeepState_ForkAndRunTest` to determine whether the test should be executed within a new process or directly in the parent process based on the passed flags. This is done by checking if the `--fork` parameter has been passed. 


The `fork` construct is not available on Windows, although the `CreateProcess` function can be used to go around this [[2]](#references). The core idea is to invoke `CreateProcess` while giving the name of the current running module file via `lpCommandLine` along with several parameters. 


The new process is invoked passing the flag `--direct_run`, which is only defined on Windows platforms, so that DeepState would know that the execution had been started via a `CreateProcess` call: when this parameter is given, DeepState recognizes that it is operating inside the new process and thus goes immediately to the execution of the `TEST` function (following the initialization procedure - shared memory allocation in `DeepState_AllocCurrentTestRun`). Along with `--direct_run` the new process is invoked with `--input_which_test`, telling the child process which test to run. 

**NOTE**: the child process has no way of knowing which test to execute, therefore the idea is to pass the extra flag `--input_which_test` along with the test name.


The Windows API provides the function `GetModuleFileName` which can be used to discover the current module's file name [[3]](#references). 
```c++
/* Get the fully qualified path of the current module */
char command[MAX_CMD_LEN]; 
if (!GetModuleFileName(NULL, command, MAX_CMD_LEN)){
  DeepState_LogFormat(DeepState_LogError, "GetModuleFileName failed (%d)", GetLastError());
  return 0;
}
```

In the meanwhile, the main process  waits for the new "child" process thanks to `WaitForSingleObject`[[4]](#references). Then, using `GetExitCodeProcess`, the exit code of the "child" process is collected [[5]](#references). 


### `DeepState_RunSingle`. 
This function has been added to DeepState since DeepState needs to know when it is being called from a CreateProcess and should then proceed directly to the execution of the provided test. The flag `--direct_run` must have been supplied to the program, as shown in the following lines of code, in order for this function to be called on Windows.

```c++
#if defined(_WIN32) || defined(_MSC_VER)
  if (FLAGS_direct_run) {
    DeepState_RunSingle();
    return 0;
  }
#endif
```

In order to discover the test that the parent process requested to execute, the child process can use the parameter supplied to `--input_which_test`. Iterating through all the tests, it compares `test->test_name` and uses `strcmp` to see whether there is a match. After being located, the test is executed by invoking the standard `DeepState_RunTest` function. When this function terminates, an exit code is generated and communicated to the parent process.



### Stats sys/stat.h
Due to the fact that this library is POSIX-specific, Windows cannot access it. To find out whether directories and files are there, several DeepState methods employ the `stat` function. `GetFileAttributes` is a similar method offered by Windows [[6]](#references).

```c++
#if defined(_WIN32) || defined(_MSC_VER)
  DWORD file_attributes = GetFileAttributes(abspath);
  if (file_attributes == INVALID_FILE_ATTRIBUTES){
    DeepState_Abandon("Specified input path does not exist.");
  }
#elif defined(__unix)
  if (stat(abspath, &statbuf) != 0) {
    DeepState_Abandon("Specified input path does not exist.");
  }
#endif
```

# How has this been tested?
MinGW(with MSYS) has been used to test this on Windows with the Built-In Fuzzer. My intention is to bring RcppDeepState to Windows by compiling DeepState using [Rtools](https://cran.r-project.org/bin/windows/Rtools/), a toolchain based on MinGW, for generating R and R packages from source on Windows [[7]](#references).

### Installation
The developer can use the `pacman` package manager to install all required dependencies before beginning the compilation phase.
```sh
pacman -S  mingw-w64-{i686,x86_64,ucrt-x86_64}-python3 mingw-w64-{i686,x86_64,ucrt-x86_64}-python-setuptools mingw-w64-{i686,x86_64,ucrt-x86_64}-gcc mingw-w64-{i686,x86_64,ucrt-x86_64}-cmake mingw-w64-{i686,x86_64,ucrt-x86_64}-libffi
```

The installation procedure remains the same.
```sh
mkdir deepstate/build && cd deepstate/build
cmake -G "Unix Makefiles" ../
make

# optionally (if running the shell as administrator)
make install
```

### Linking and Test
After DeepState had been successfully built, I tested it by manually creating a basic test harness `test.cpp` and compiling it using the `Makefile` shown below:
```make
DEEPSTATE_LIB="C:/Users/user/Downloads/deepstate-master/build"
DEEPSTATE_INCUDE="C:/Users/user/Downloads/deepstate-master/src/include"

CPPFLAGS=-I${DEEPSTATE_INCUDE}
LDFLAGS=-L${DEEPSTATE_LIB} -Wl,-rpath=${DEEPSTATE_LIB}
LDLIBS=-ldeepstate

test : test.o
	g++ -std=c++11 test.o ${CPPFLAGS} ${LDFLAGS} ${LDLIBS} -o test

test.o : test.cpp
	g++ -std=c++11 -c ${CPPFLAGS} test.cpp -o test.o
```


# Todo
* Since `fnmatch` is not available in Windows at this time, all tests are run on Windows regardless of the `--test_filter` parameter. 


# References
[1] [Creating Named Shared Memory](https://learn.microsoft.com/en-us/windows/win32/memory/creating-named-shared-memory)

[2] [Creating processes](https://learn.microsoft.com/en-us/windows/win32/procthread/creating-processes)

[3] [GetModuleFileName function](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulefilenamea)

[4] [WaitForSingleObject function](https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitforsingleobject)

[5] [GetExitCodeProcess function](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getexitcodeprocess)

[6] [GetFileAttributes function](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfileattributesa)

[7] [Using Rtools4 on Windows](https://cran.r-project.org/bin/windows/Rtools/rtools40.html)