### PR TITLE
Preprocessing directives bug fix 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Table of Contents
      * [Supported Platforms](#supported-platforms)
      * [Dependencies](#dependencies)
      * [Building on Ubuntu 18.04 (Bionic)](#building-on-ubuntu-1804-bionic)
+     * [Building on Windows 10](#building-on-windows-10)
      * [Installing](#installing)
      * [Installation testing](#installation-testing)
      * [Docker](#docker)

--- a/src/include/deepstate/DeepState.h
+++ b/src/include/deepstate/DeepState.h
@@ -299,6 +299,10 @@ extern void *DeepState_MemScrub(void *pointer, size_t data_size);
 /* Checks if the given path corresponds to a regular file. */
 extern bool DeepState_IsRegularFile(char *path);
 
+/* Returns the path to a testcase without parsing to any aforementioned types. 
+ * Platform specific function. */
+extern char *DeepState_InputPath(const char* testcase_path);
+
 #define DEEPSTATE_MAKE_SYMBOLIC_ARRAY(Tname, tname, utname) \
     DEEPSTATE_INLINE static \
     tname *DeepState_Symbolic ## Tname ## Array(size_t num_elms) { \

--- a/src/lib/DeepState.h
+++ b/src/lib/DeepState.h
@@ -32,10 +32,6 @@ extern void DeepState_RunSavedTakeOverCases(jmp_buf env, struct DeepState_TestIn
 /* Run take over. Platform specific function. */
 extern int DeepState_TakeOver(void);
 
-/* Returns the path to a testcase without parsing to any aforementioned types. 
- * Platform specific function. */
-extern char *DeepState_InputPath(const char* testcase_path);
-
 
 DEEPSTATE_END_EXTERN_C
 


### PR DESCRIPTION
This pull request is primarily intended to address a minor compilation error introduced by pull request #423: the use of `#ifdef` inside the preprocessing directive `#define` is not allowed because the macro-replaced preprocessing token sequence is not processed as a preprocessing directive (taken from [C11 standard n1570](http://port70.net/nsz/c/c11/n1570.html#6.10.3.4p3)). Taking `#ifdef` outside of `#define` fixed the issue.

With this pull request, I also moved back the `DeepState_InputPath` function definition to the public header file `include/deepstate/DeepState.h` because `examples/InputPath.cpp` requires it. 